### PR TITLE
fix(core): Windows EINVAL when spawning .cmd backend executables (Vibe Kanban)

### DIFF
--- a/packages/core/src/manager/launcher/process-launcher.ts
+++ b/packages/core/src/manager/launcher/process-launcher.ts
@@ -65,10 +65,13 @@ export class ProcessLauncher implements AgentLauncher {
       stdio = "ignore";
     }
 
+    const needsShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(command);
+
     const child = spawn(command, args, {
       cwd: workspaceDir,
       detached: !useAcp,
       stdio,
+      shell: needsShell,
     });
 
     const spawnResult = await new Promise<{ pid: number } | { error: Error }>((resolve) => {


### PR DESCRIPTION
## Summary

Fix `ProcessLauncher.launch()` failing with `EINVAL` on Windows when the resolved backend command is a `.cmd` file (e.g. `claude-agent-acp.cmd`, `cursor.cmd`).

- On Windows, Node.js `child_process.spawn()` cannot directly execute `.cmd`/`.bat` files — it requires `shell: true`
- The error was masked by `isSpawnNotFound()` matching `EINVAL`, producing a misleading "executable not found" message even though the CLI was properly installed
- The sibling `AcpConnection.spawn()` in `@actant/acp` already handled this correctly with `shell: isWindows()`, but `ProcessLauncher` was missed

## Changes

**`packages/core/src/manager/launcher/process-launcher.ts`**

Added targeted `shell` option to the `spawn()` call:

```typescript
const needsShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(command);
```

This only enables `shell: true` for `.cmd`/`.bat` files, avoiding side effects on direct executables (e.g. `node`) where `shell: true` + `detached: true` would cause `cmd.exe` to act as an intermediate parent process.

## Root Cause Analysis

1. `actant agent start qa` calls `AgentManager.startAgent()`
2. `startAgent()` calls `ProcessLauncher.launch()` which resolves `claude-code` to `claude-agent-acp.cmd` (via `builtin-backends.ts` `resolveCommand.win32`)
3. `spawn("claude-agent-acp.cmd", [], { detached: false, stdio: ["pipe","pipe","pipe"] })` throws `EINVAL` synchronously
4. The catch block in `AgentManager.startAgent()` matches `EINVAL` via `isSpawnNotFound()` and wraps it as `Backend "claude-code" executable not found` — a misleading message when the binary is actually installed

## Verification

- Reproduced the EINVAL with a minimal Node.js test: `spawn("claude-agent-acp.cmd")` fails with EINVAL; `spawn("claude-agent-acp.cmd", { shell: true })` succeeds
- All existing `ProcessLauncher` tests pass (5/5)
- The one pre-existing failure in `agent-lifecycle-scenarios.test.ts` ("mixed concurrent agents") is unrelated and reproduces on the base branch

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
