### PR TITLE
docs(trellis): update developer identity spec to use Actant Agent model

### DIFF
--- a/.claude/commands/trellis/plan-start.md
+++ b/.claude/commands/trellis/plan-start.md
@@ -32,10 +32,10 @@ cat .trellis/workflow.md
 Ensure your Actant Agent identity is initialized. Check if already set, if not, initialize:
 
 ```bash
-./.trellis/scripts/get-developer.sh || ./.trellis/scripts/init-developer.sh claude-agent
+./.trellis/scripts/get-developer.sh || ./.trellis/scripts/init-developer.sh actant-claude-agent
 ```
 
-> **Actant Agent 身份**: AI 开发者是一个 Actant Agent 实例。Claude Code 使用 `claude-agent` 作为身份标识。
+> **Actant Agent 身份**: AI 开发者是一个 Actant Agent 实例。Claude Code 使用 `actant-claude-agent` 作为身份标识。
 
 ### Step 0.3: Get Current Context
 

--- a/.cursor/commands/trellis-plan-start.md
+++ b/.cursor/commands/trellis-plan-start.md
@@ -30,10 +30,10 @@ cat .trellis/workflow.md
 Ensure your Actant Agent identity is initialized. Check if already set, if not, initialize:
 
 ```bash
-./.trellis/scripts/get-developer.sh || ./.trellis/scripts/init-developer.sh cursor-agent
+./.trellis/scripts/get-developer.sh || ./.trellis/scripts/init-developer.sh actant-cursor-agent
 ```
 
-> **Actant Agent 身份**: AI 开发者是一个 Actant Agent 实例。Cursor AI 使用 `cursor-agent` 作为身份标识。
+> **Actant Agent 身份**: AI 开发者是一个 Actant Agent 实例。Cursor AI 使用 `actant-cursor-agent` 作为身份标识。
 
 ### Step 0.3: Get Current Status
 

--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -29,7 +29,7 @@
 
 # If not initialized, run:
 ./.trellis/scripts/init-developer.sh <your-name>
-# Example: ./.trellis/scripts/init-developer.sh cursor-agent
+# Example: ./.trellis/scripts/init-developer.sh actant-cursor-agent
 ```
 
 This creates:
@@ -40,10 +40,10 @@ This creates:
 
 | Agent 类型 | 推荐名称 | 说明 |
 |-----------|---------|------|
-| Cursor AI | `cursor-agent` | 使用 `/trellis-plan-start` 启动会话 |
-| Claude Code | `claude-agent` | 使用 `/trellis:plan-start` 启动会话 |
-| Human developer | `<your-name>` | e.g., `john-doe` |
-| Task-scoped agent | `<platform>-<task>` | e.g., `cursor-refactor`, `claude-qa` |
+| Cursor AI | `actant-cursor-agent` | 使用 `/trellis-plan-start` 启动会话 |
+| Claude Code | `actant-claude-agent` | 使用 `/trellis:plan-start` 启动会话 |
+| Human developer | `actant-<your-name>` | e.g., `actant-john-doe` |
+| Task-scoped agent | `actant-<platform>-<task>` | e.g., `actant-cursor-refactor`, `actant-claude-qa` |
 
 > **理念**: 每个 AI 开发者会话对应一个 Actant Agent 实例。身份初始化后，通过 `/trellis-plan-start`（Cursor）或 `/trellis:plan-start`（Claude Code）启动 plan-first 工作流，确保先规划再执行。
 
@@ -424,7 +424,7 @@ gh issue create -t "<title>" -b "<body>" -l "feature"
 ```bash
 ./.trellis/scripts/issue.sh list [--milestone mid-term] [--priority P1] [--rfc]
 ./.trellis/scripts/issue.sh show <id>
-./.trellis/scripts/issue.sh edit <id> --assign cursor-agent --milestone mid-term  # ← auto-sync
+./.trellis/scripts/issue.sh edit <id> --assign actant-cursor-agent --milestone mid-term  # ← auto-sync
 ./.trellis/scripts/issue.sh label <id> --add rfc --remove question               # ← auto-sync
 ./.trellis/scripts/issue.sh comment <id> "Design doc completed"                  # ← auto-sync
 ./.trellis/scripts/issue.sh close <id> --as completed                            # ← auto-sync + auto-archive


### PR DESCRIPTION
## Summary

- Update developer identity spec to use Actant Agent model with `actant` prefix
- Add Step 0.2 (Initialize Developer Identity) to both Cursor and Claude `plan-start` commands
- Standardize all identity names: `actant-cursor-agent`, `actant-claude-agent`, `actant-<name>`

## Changes

### `workflow.md`
- Add Actant Agent model description: AI developers are Actant Agent instances
- Replace naming suggestions with structured table, all with `actant` prefix
- Update issue assign example accordingly

### `.cursor/commands/trellis-plan-start.md`
- Add Step 0.2: auto-check and init `actant-cursor-agent` identity
- Renumber subsequent steps

### `.claude/commands/trellis/plan-start.md`
- Add Step 0.2: auto-check and init `actant-claude-agent` identity
- Renumber subsequent steps

## Test plan

- [ ] Verify all identity names in `workflow.md` have `actant` prefix
- [ ] Verify Cursor and Claude `plan-start` commands include Step 0.2
- [ ] Verify `init-developer.sh actant-cursor-agent` creates workspace correctly
