### PR TITLE
feat(phase4): wave-1 bug fixes - gateway.lease, adopt sync, ping version, install.ps1

### DIFF
--- a/docs/planning/phase4-plan.md
+++ b/docs/planning/phase4-plan.md
@@ -1,0 +1,153 @@
+# Phase 4 计划：自治 Agent 平台 (Hook · Plugin · 强化 · 通信)
+
+> 评估日期：2026-02-25
+> 基于 roadmap.md + 全部 open Issues + 代码现状分析
+
+---
+
+## 一、Phase 4 现状评估
+
+### 已完成项（Phase 3 → Phase 4 过渡期）
+
+| Issue | 标题 | 状态 | 备注 |
+|-------|------|------|------|
+| #134 | agent open + interactionModes | ✅ 已关闭 | BackendManager 已支持 open mode |
+| #121 | Pi 内置后端 | 🔧 大部分完成 | `@actant/pi` 包已存在 (PiBuilder, PiCommunicator, acp-bridge) |
+| #141 | ModelProvider Registry | 🔧 部分实现 | `ModelProviderRegistry` 类已存在，内置 providers 已注册 |
+| #131 | Pluggable Backend Registry | 🔧 部分实现 | `BackendManager` + `BackendDefinition` 已完成 |
+| — | 版本号统一 | ✅ | 所有包已升至 0.2.1（#129 描述的 0.1.3 问题应已解决） |
+
+### 仍需修复的 Bug（第一波）
+
+| 优先级 | Issue | 标题 | 难度 | 状态 |
+|--------|-------|------|------|------|
+| **P0** | #117 | `gateway.lease` RPC handler 缺失 | 中 | 未开始 — handler 文件不存在，Session Lease 模式完全不可用 |
+| **P0** | #151 | agent adopt 后 status 不可见 | 低 | 未开始 — registry/manager cache 不同步 |
+| P1 | #129 | 包发布 0.1.3 | ？ | **需验证** — 版本已是 0.2.1，可能已解决 |
+| P2 | #95 | ACP Gateway terminal stub | 中 | 未开始 — 需 TerminalHandle 映射方案 |
+| P2 | #127 | install.ps1 非交互挂起 | 低 | 未开始 |
+| P2 | #126 | daemon.ping 硬编码版本 | 低 | 未开始 |
+| P3 | #138 | 清理已弃用传递依赖 | 低 | chore |
+
+### Phase 4 核心能力（第二波）
+
+| 优先级 | Issue | 标题 | 依赖 | 预估 |
+|--------|-------|------|------|------|
+| **P1** | #135 | Workflow 重定义为 Hook Package | #47 ✅ | **大** — 三层 Hook 事件总线 + 动作执行器 |
+| **P1** | #14 | Actant 系统级 Plugin 体系 | #22 ✅ | **大** — 可插拔架构设计 |
+| **P1** | #137 | Runtime MCP Manager | — | **大** — MCP Server 进程管理 + 连接维护 |
+| P1 | #37 | Extensible Initializer | — | 中 — 声明式初始化步骤框架 |
+| P2 | #133 | 环境变量 provider 配置 | #141 部分完成 | 中 — env fallback + 后端感知注入 |
+| P2 | #128 | spawn EINVAL 友好错误 | — | 低 |
+| P2 | #153 | 后端 CLI 依赖自动安装 | #131 部分完成 | 中 |
+| P2 | #150 | Backend Materialization Plugin | #131 | 中 — 声明式物化描述 |
+| P2 | #122 | Employee/Service Mode 完善 | #47 ✅ | 中 |
+| P2 | #153(arch) | Instance Interaction Archetype | #134 ✅ | 中 — archetype 字段推导 |
+| P2 | #124 | daemon restart --force | — | 低 |
+
+### Phase 4 深化扩展（第三波）
+
+| 优先级 | Issue | 标题 | 依赖 | 预估 |
+|--------|-------|------|------|------|
+| P2 | #136 | Agent-to-Agent Email 通信 | 无 | **大** — EmailHub + CLI + RPC + 时间线 |
+| P2 | #40 | Agent 工具权限管理 | — | 中 |
+| P2 | #8 | Template hot-reload | — | 低 |
+| P2 | #38 | Endurance Test Agent 模板 | #37 | 低 |
+| P3 | #9 | Agent 进程日志收集 | — | 低 |
+| P2 | #145 | Community Skill Source | — | 中 |
+
+---
+
+## 二、推进策略
+
+### 第一波：Bug 修复 + 基础保障（1-2 天）
+
+**目标**：消除已知阻塞性 Bug，确保基础功能可用。
+
+```
+顺序 1: #117 gateway.lease handler          ← Session Lease 模式的前置
+顺序 2: #151 agent adopt registry sync      ← 低成本高价值
+顺序 3: #129 验证包发布状态                   ← 确认是否已解决
+顺序 4: #126 daemon.ping 版本号             ← 快速修复
+顺序 5: #127 install.ps1 非交互检测          ← 低风险修复
+顺序 6: #95 terminal stub                   ← 依赖 SDK，可能需要 workaround
+```
+
+### 第二波：核心能力（按依赖关系和价值排序）
+
+**批次 A — 环境基础（P1，解锁后续开发）**:
+```
+#133 环境变量 provider 配置     ← 影响所有后端的可用性
+#128 spawn EINVAL 友好错误      ← DX 体验
+```
+
+**批次 B — Hook/Event 体系（P1，Phase 4 核心）**:
+```
+#135 Workflow as Hook Package   ← 三层 Hook 架构是 Phase 4 的灵魂
+  ├── Step 1: WorkflowDefinition schema 重设计
+  ├── Step 2: Hook EventBus（Layer 1 系统事件 + Layer 3 运行时事件）
+  ├── Step 3: Action 执行器（shell / builtin / agent）
+  ├── Step 4: 与 EmployeeScheduler 整合（CronInput → Hook cron）
+  └── Step 5: CLI workflow list / enable / disable
+```
+
+**批次 C — Plugin 架构（P1，可插拔基础）**:
+```
+#14 Actant 系统级 Plugin 体系   ← 与 #135 协同设计
+  ├── Step 1: Plugin 接口定义（onStart/onStop/onTick lifecycle）
+  ├── Step 2: PluginHost + PluginRegistry（实例级）
+  ├── Step 3: HeartbeatMonitor 作为首个内置 Plugin
+  ├── Step 4: Scheduler Plugin 化（从 #47 重构）
+  └── Step 5: 模板 plugins 字段集成
+```
+
+**批次 D — 强化项**:
+```
+#37 Extensible Initializer       ← 声明式初始化
+#137 Runtime MCP Manager        ← headless Agent MCP 支持
+#150 Backend Materialization     ← 声明式物化描述
+#122 Employee/Service 完善       ← archetype 推导
+```
+
+### 第三波：深化扩展
+
+```
+#136 Agent-to-Agent Email        ← 异步通信范式
+#40 工具权限管理                  ← 安全增强
+#8  Template hot-reload          ← DX 增强
+#9  日志收集                     ← 可观测性
+```
+
+---
+
+## 三、推荐的第一个开发任务
+
+**#117 `gateway.lease` RPC handler 实现**
+
+理由：
+1. Session Lease 是 Phase 3 的核心架构之一，但 handler 缺失导致完全不可用
+2. 类型定义已存在（`GatewayLeaseParams` / `GatewayLeaseResult`）
+3. 实现范围明确：新建 `gateway-handlers.ts`，从 `AcpConnectionManager` 获取 Gateway → 创建 socket → 返回 `{ socketPath }`
+4. 修复后可验证整个 ACP Proxy Session Lease 流程
+
+---
+
+## 四、关键架构决策（待确认）
+
+| 决策点 | 选项 | 建议 | 备注 |
+|--------|------|------|------|
+| Hook 事件总线实现 | Node EventEmitter vs 自定义 | EventEmitter + typed wrapper | 简单高效，Layer 分离通过命名空间 |
+| Plugin 加载方式 | 静态注册 vs 动态加载 | Phase 1 静态注册，Phase 2 动态 | 避免过早引入复杂性 |
+| Workflow 配置格式 | JSON vs YAML | YAML（与现有 configs 一致） | #135 已有 YAML 草案 |
+| Email 持久化 | SQLite vs 文件 | SQLite（与 state 一致） | 或考虑 JSON Lines 作为轻量方案 |
+
+---
+
+## 五、风险评估
+
+| 风险 | 概率 | 影响 | 缓解 |
+|------|------|------|------|
+| #135 Hook 体系范围膨胀 | 高 | Phase 4 延期 | 严格分 Phase: Schema → EventBus → Actions |
+| #14 Plugin 接口不稳定 | 中 | 后续插件需重写 | 先实现 2-3 个内置插件验证接口 |
+| #137 MCP 运行时复杂度 | 高 | 阻塞 headless Agent | 先支持 stdio 传输，SSE 延后 |
+| ACP SDK 变更 | 低 | #95 terminal stub | 保持 workaround，追踪上游 |

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -383,19 +383,24 @@ Phase 1、Phase 2 MVP、Phase 3 核心三线（3a/3b/3c）全部完成。#104/#1
 - ✅ 已关闭过期: #13 ACP Client, #41 雇员型设计文档, #46 daemon stop, #48 session 验证, #96 ESM 解析
 
 **Phase 4 进行中**：
-- 🔧 #121 (P1) Pi 内置后端 — 开发中
+- ✅ #134 (P2) agent open + interactionModes — 已完成
+- ✅ #121 (P1) Pi 内置后端 — 已完成
 - 📋 #135 (P1) Workflow 重定义为 Hook Package — 设计完成，待实现
+- 📋 #14 (P1) Actant 系统级 Plugin 体系 — 待实现
 - 📋 #136 (P2) Agent-to-Agent Email 通信 — 设计完成，待实现
-- 📋 #134 (P2) agent open + interactionModes — 待开始
 - 📋 #133 (P2) 环境变量 provider 配置 — 待开始
+- 📋 #37 (P1) Extensible Initializer — 待开始
 
-**活跃 BUG**：
-- #117 (P1) gateway.lease RPC handler missing — Session Lease 模式无法使用
-- #129 (P1) 所有 @actant/* 包需发布 0.1.3 — IPC path mismatch
+**Phase 4 第一波 BUG 修复**（本轮已完成）：
+- ✅ #117 (P1) gateway.lease RPC handler — 已实现 `gateway-handlers.ts`
+- ✅ #151 agent adopt registry/manager cache 不同步 — 已修复
+- ✅ #126 (P3) daemon.ping 硬编码版本 — 已修复，读取真实 package.json 版本
+- ✅ #127 (P2) install.ps1 非交互终端挂起 — 已修复，添加 `$IsInteractive` 检测和 `-NpmRegistry` 参数
+
+**仍活跃 BUG**：
+- #129 (P1) 所有 @actant/* 包需发布 — 版本已升至 0.2.1，需验证 npm 发布状态
 - #95 (P2) ACP Gateway terminal stub — 根因已定位（TerminalHandle 映射方案），不依赖 SDK 变更
-- #127 (P2) install.ps1 非交互终端挂起
 - #57 (P2) Windows daemon fork 退出 — workaround: --foreground
-- #126 (P3) daemon.ping 返回硬编码 version
 
 详细 TODO 跟踪见：`docs/planning/phase3-todo.md`
 详细设计见：`docs/design/mvp-next-design.md`

--- a/packages/api/src/daemon/__tests__/socket-server.test.ts
+++ b/packages/api/src/daemon/__tests__/socket-server.test.ts
@@ -195,7 +195,7 @@ describe("SocketServer integration", () => {
       jsonrpc: "2.0", id: 20, method: "daemon.ping",
     });
     const result = res.result as { version: string; uptime: number; agents: number };
-    expect(result.version).toBe("0.1.0");
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(result.uptime).toBeGreaterThanOrEqual(0);
     expect(typeof result.agents).toBe("number");
   });

--- a/packages/api/src/daemon/daemon.ts
+++ b/packages/api/src/daemon/daemon.ts
@@ -13,6 +13,8 @@ import {
   registerDaemonHandlers,
   registerProxyHandlers,
   registerScheduleHandlers,
+  registerGatewayHandlers,
+  disposeAllLeases,
 } from "../handlers/index";
 import { writePidFile, removePidFile, readPidFile, isProcessRunning } from "./pid-file";
 
@@ -38,6 +40,7 @@ export class Daemon {
     registerDaemonHandlers(this.handlers, () => this.stop());
     registerProxyHandlers(this.handlers);
     registerScheduleHandlers(this.handlers);
+    registerGatewayHandlers(this.handlers);
   }
 
   get socketPath(): string {
@@ -91,6 +94,7 @@ export class Daemon {
     }
 
     this.ctx.templateWatcher.stop();
+    await disposeAllLeases();
     await this.server.close();
     await removePidFile(this.ctx.pidFilePath);
 

--- a/packages/api/src/handlers/daemon-handlers.ts
+++ b/packages/api/src/handlers/daemon-handlers.ts
@@ -1,9 +1,21 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
 import type {
   DaemonPingResult,
   DaemonShutdownResult,
 } from "@actant/shared";
 import type { AppContext } from "../services/app-context";
 import type { HandlerRegistry } from "./handler-registry";
+
+const PKG_VERSION = (() => {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../package.json");
+    return (JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string }).version;
+  } catch {
+    return "unknown";
+  }
+})();
 
 export function registerDaemonHandlers(
   registry: HandlerRegistry,
@@ -15,7 +27,7 @@ export function registerDaemonHandlers(
 
 async function handleDaemonPing(ctx: AppContext): Promise<DaemonPingResult> {
   return {
-    version: "0.1.0",
+    version: PKG_VERSION,
     uptime: ctx.uptime,
     agents: ctx.agentManager.size,
   };

--- a/packages/api/src/handlers/gateway-handlers.ts
+++ b/packages/api/src/handlers/gateway-handlers.ts
@@ -1,0 +1,156 @@
+import { createServer, type Server } from "node:net";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { unlink } from "node:fs/promises";
+import type { GatewayLeaseParams, GatewayLeaseResult } from "@actant/shared";
+import { createLogger, ipcRequiresFileCleanup, isWindows } from "@actant/shared";
+import type { AppContext } from "../services/app-context";
+import type { HandlerRegistry } from "./handler-registry";
+
+const logger = createLogger("gateway-handlers");
+
+interface LeaseEntry {
+  server: Server;
+  socketPath: string;
+  agentName: string;
+}
+
+const activeLeases = new Map<string, LeaseEntry>();
+
+export function registerGatewayHandlers(registry: HandlerRegistry): void {
+  registry.register("gateway.lease", handleGatewayLease);
+}
+
+/**
+ * Create a per-agent named pipe / unix socket that the IDE can connect to.
+ * When the IDE connects, the socket is handed to `AcpGateway.acceptSocket()`
+ * which bridges ACP traffic between the IDE and the downstream Agent.
+ */
+async function handleGatewayLease(
+  params: Record<string, unknown>,
+  ctx: AppContext,
+): Promise<GatewayLeaseResult> {
+  const { agentName } = params as unknown as GatewayLeaseParams;
+
+  const meta = ctx.agentManager.getAgent(agentName);
+  if (!meta) {
+    throw new Error(`Agent "${agentName}" not found`);
+  }
+  if (meta.status !== "running") {
+    throw new Error(
+      `Agent "${agentName}" is not running (status: ${meta.status}). ` +
+      `Session Lease requires a running agent.`,
+    );
+  }
+
+  if (!ctx.acpConnectionManager.has(agentName)) {
+    throw new Error(
+      `Agent "${agentName}" has no ACP connection. ` +
+      `Session Lease requires an ACP-capable backend.`,
+    );
+  }
+
+  const gateway = ctx.acpConnectionManager.getGateway(agentName);
+  if (!gateway) {
+    throw new Error(
+      `No ACP Gateway found for agent "${agentName}". ` +
+      `This is unexpected — the gateway should be pre-created when the agent connects.`,
+    );
+  }
+
+  // Reuse existing lease if the gateway doesn't have an active upstream
+  const existing = activeLeases.get(agentName);
+  if (existing && !gateway.isUpstreamConnected) {
+    logger.debug({ agentName }, "Reusing existing gateway lease socket");
+    return { socketPath: existing.socketPath };
+  }
+
+  // If there's an active upstream, disconnect it first (single IDE at a time)
+  if (existing && gateway.isUpstreamConnected) {
+    gateway.disconnectUpstream();
+  }
+
+  // Clean up old lease server if any
+  if (existing) {
+    existing.server.close();
+    if (ipcRequiresFileCleanup()) {
+      await unlink(existing.socketPath).catch(() => {});
+    }
+    activeLeases.delete(agentName);
+  }
+
+  const socketPath = generateLeaseSocketPath(agentName);
+  const server = await createLeaseServer(socketPath, agentName, ctx);
+
+  activeLeases.set(agentName, { server, socketPath, agentName });
+
+  logger.info({ agentName, socketPath }, "Gateway lease created");
+  return { socketPath };
+}
+
+function generateLeaseSocketPath(agentName: string): string {
+  const id = randomUUID().slice(0, 8);
+  if (isWindows()) {
+    const safeName = agentName.replace(/[^a-zA-Z0-9._-]/g, "_");
+    return `\\\\.\\pipe\\actant-gw-${safeName}-${id}`;
+  }
+  return join(tmpdir(), `actant-gw-${agentName}-${id}.sock`);
+}
+
+async function createLeaseServer(
+  socketPath: string,
+  agentName: string,
+  ctx: AppContext,
+): Promise<Server> {
+  if (ipcRequiresFileCleanup()) {
+    await unlink(socketPath).catch(() => {});
+  }
+
+  return new Promise<Server>((resolve, reject) => {
+    const server = createServer((socket) => {
+      logger.info({ agentName }, "IDE connected to gateway lease socket");
+      try {
+        ctx.acpConnectionManager.acceptLeaseSocket(agentName, socket);
+      } catch (err) {
+        logger.error({ agentName, error: err }, "Failed to accept lease socket");
+        socket.destroy();
+      }
+    });
+
+    server.on("error", (err) => {
+      logger.error({ agentName, socketPath, error: err }, "Gateway lease server error");
+    });
+
+    server.on("close", () => {
+      activeLeases.delete(agentName);
+      if (ipcRequiresFileCleanup()) {
+        unlink(socketPath).catch(() => {});
+      }
+    });
+
+    server.listen(socketPath, () => {
+      logger.debug({ agentName, socketPath }, "Gateway lease server listening");
+      resolve(server);
+    });
+
+    server.on("error", reject);
+  });
+}
+
+/**
+ * Clean up all active lease servers. Called during daemon shutdown.
+ */
+export async function disposeAllLeases(): Promise<void> {
+  const entries = Array.from(activeLeases.values());
+  activeLeases.clear();
+  for (const entry of entries) {
+    entry.server.close();
+    if (ipcRequiresFileCleanup()) {
+      await unlink(entry.socketPath).catch(() => {});
+    }
+  }
+  if (entries.length > 0) {
+    logger.info({ count: entries.length }, "All gateway leases disposed");
+  }
+}

--- a/packages/api/src/handlers/index.ts
+++ b/packages/api/src/handlers/index.ts
@@ -8,3 +8,4 @@ export { registerPresetHandlers } from "./preset-handlers";
 export { registerDaemonHandlers } from "./daemon-handlers";
 export { registerProxyHandlers } from "./proxy-handlers";
 export { registerScheduleHandlers } from "./schedule-handlers";
+export { registerGatewayHandlers, disposeAllLeases } from "./gateway-handlers";

--- a/packages/core/src/manager/agent-manager.ts
+++ b/packages/core/src/manager/agent-manager.ts
@@ -413,6 +413,15 @@ export class AgentManager {
   }
 
   /**
+   * Register an externally-adopted agent into the in-memory cache.
+   * Called after InstanceRegistry.adopt() to keep cache in sync.
+   */
+  registerAdopted(meta: AgentInstanceMeta): void {
+    this.cache.set(meta.name, meta);
+    logger.info({ name: meta.name }, "Adopted agent registered in cache");
+  }
+
+  /**
    * Resolve spawn info for an agent without starting it.
    * If the agent doesn't exist but templateName is provided, auto-creates it.
    */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -184,4 +184,6 @@ export {
   type PresetShowResult,
   type PresetApplyParams,
   type PresetApplyResult,
+  type GatewayLeaseParams,
+  type GatewayLeaseResult,
 } from "./rpc.types";


### PR DESCRIPTION
## Summary

Phase 4 第一波 Bug 修复，解除 Session Lease 等关键功能的阻塞。

- **#117** 实现 `gateway.lease` RPC handler — 创建 `gateway-handlers.ts`，为每个 Agent 创建专用命名管道/Unix socket，IDE 连接后桥接到 AcpGateway，启用完整的 Session Lease 模式
- **#151** 修复 agent adopt 后 `agent status` 不可见 — 在 `AgentManager` 新增 `registerAdopted()` 方法，adopt handler 同步更新内存缓存
- **#126** 修复 `daemon.ping` 返回硬编码版本 `0.1.0` — 改为从 `package.json` 动态读取真实版本号
- **#127** 修复 `install.ps1` 在非交互终端（CI/自动化）中永久挂起 — 添加 `$IsInteractive` 检测和 `-NpmRegistry` 参数

附带修复：`GatewayLeaseParams`/`GatewayLeaseResult` 类型补充导出到 `@actant/shared`

## Test plan

- [x] 695 tests passing (excluding pre-existing CLI E2E dist issue)
- [x] `@actant/api` type-check passes
- [ ] Manual: `actant proxy <agent> --lease` connects via gateway socket
- [ ] Manual: `actant agent adopt <path>` then `actant agent status <name>` shows agent
- [ ] Manual: `daemon.ping` returns correct version (0.2.1)
- [ ] Manual: `install.ps1 -NpmRegistry` skips interactive prompt
