### PR TITLE
fix(api): initialize EmployeeScheduler on agent start (#152)

### DIFF
--- a/packages/cli/src/__tests__/e2e-cli.test.ts
+++ b/packages/cli/src/__tests__/e2e-cli.test.ts
@@ -83,7 +83,7 @@ describe("CLI E2E (stdio)", () => {
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout);
     expect(result.running).toBe(true);
-    expect(result.version).toBe("0.1.0");
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it("template list shows empty list", async () => {


### PR DESCRIPTION
## Summary

- **#152** `agent start` 启动含 `schedule` 配置的 Agent 时，现在会自动创建 `EmployeeScheduler` 并注册到 `ctx.schedulers`。之前 `ctx.schedulers` 始终为空 Map，导致 `agent dispatch` 永远返回 `{ queued: false }`
- `handleAgentStop` / `handleAgentDestroy` 中增加 scheduler 清理逻辑（`stop()` + `delete`）
- 附带修复 CLI E2E 测试中 `daemon.ping` 版本号硬编码为 `"0.1.0"` 的断言（改为 semver pattern match）

## Test plan

- [x] 760/760 tests passing（包括修复后的 CLI E2E daemon status 测试）
- [x] `@actant/api` agent-handlers type-check passes
- [ ] Manual: `actant agent start <sched-agent>` → `actant schedule list <sched-agent>` shows configured sources
- [ ] Manual: `actant agent dispatch <sched-agent> -m "test"` → returns `{ queued: true }`
- [ ] Manual: `actant agent stop <sched-agent>` → scheduler properly cleaned up
