### PR TITLE
refactor: rename LaunchMode acp-service to normal (#154) (Vibe Kanban)

### DIFF
--- a/.trellis/issues/0153-instance-interaction-archetype.md
+++ b/.trellis/issues/0153-instance-interaction-archetype.md
@@ -1,6 +1,6 @@
 ## 动机
 
-当前 `AgentInstanceMeta` 具备 `interactionModes`（open / start / chat / run / proxy）、`launchMode`（direct / acp-background / acp-service / one-shot）和 `schedule` 配置，但缺少一个高层语义字段来描述 **实例的交互范式（archetype）**。用户无法通过单一配置声明"这个 Agent 是自主运行的雇员型"或"这是按需调用的工具型"，导致：
+当前 `AgentInstanceMeta` 具备 `interactionModes`（open / start / chat / run / proxy）、`launchMode`（direct / acp-background / normal / one-shot）和 `schedule` 配置，但缺少一个高层语义字段来描述 **实例的交互范式（archetype）**。用户无法通过单一配置声明"这个 Agent 是自主运行的雇员型"或"这是按需调用的工具型"，导致：
 
 1. **雇员型 Agent 无法自动启动** — 系统启动或 API 启动时无法自动拉起配有 schedule 的 Agent
 2. **交互约束散落各处** — `interactionModes` 控制 CLI 命令可用性，`launchMode` 控制进程模式，`schedule` 控制任务调度，但三者之间缺乏上层关联
@@ -20,7 +20,7 @@ export type AgentArchetype = "tool" | "employee" | "service";
 |------------|--------------------------|----------------------------------------------|
 | `tool`     | 按需工具型（默认）        | 用户主动 open/start，无自动启动              |
 | `employee` | 自主雇员型               | 自动启动 + schedule 驱动，后台持续运行       |
-| `service`  | 服务型（API/ACP 对外暴露）| 自动启动，以 acp-service 模式监听请求        |
+| `service`  | 服务型（API/ACP 对外暴露）| 自动启动，以 normal 模式监听请求        |
 
 ### 2. 雇员型自动启动能力
 
@@ -36,7 +36,7 @@ export type AgentArchetype = "tool" | "employee" | "service";
 |------------|----------------------------|--------------------|
 | `tool`     | `["open", "start", "chat"]`| `direct`           |
 | `employee` | `["start", "run", "proxy"]`| `acp-background`   |
-| `service`  | `["proxy"]`                | `acp-service`      |
+| `service`  | `["proxy"]`                | `normal`      |
 
 用户仍可在 template 中显式覆盖。
 

--- a/.trellis/spec/agent-lifecycle.md
+++ b/.trellis/spec/agent-lifecycle.md
@@ -180,7 +180,7 @@ actant agent stop review-agent
 
 ---
 
-### 3.3 acp-service — 持久服务模式
+### 3.3 normal — 持久服务模式
 
 ```
 Actant Daemon (守护者)
@@ -206,7 +206,7 @@ Actant workspace (persistent)
 
 **典型流程**：
 ```
-actant agent create pr-reviewer -t pr-review --launch-mode acp-service
+actant agent create pr-reviewer -t pr-review --launch-mode normal
 actant agent start pr-reviewer
 # Agent 持续运行...
 # 崩溃？Actant 自动重启（指数退避）
@@ -215,7 +215,7 @@ actant agent start pr-reviewer
 
 **与 acp-background 的区别**：
 
-| 维度 | acp-background | acp-service |
+| 维度 | acp-background | normal |
 |------|---------------|-------------|
 | 谁决定何时终止 | 调用方 | Actant（或管理员手动） |
 | 崩溃处理 | 标记 error/crashed，不自动重启 | **自动重启**（指数退避） |
@@ -269,7 +269,7 @@ actant agent start task-123
 
 ### 3.5 LaunchMode 对比总览
 
-| 维度 | direct | acp-background | acp-service | one-shot |
+| 维度 | direct | acp-background | normal | one-shot |
 |------|--------|---------------|-------------|----------|
 | 进程形态 | 有 UI | headless | headless | headless |
 | 生命周期所有者 | 用户 | 调用方 | Actant | Actant |
@@ -619,13 +619,13 @@ actant.detach("task-123", { cleanup: true })
 
 | 选择 | 推荐 |
 |------|------|
-| LaunchMode | `acp-service` |
+| LaunchMode | `normal` |
 | WorkspacePolicy | `persistent` |
 | 接入模式 | **ACP Proxy**（标准协议）或 **agent.prompt**（API 调用） |
 
 ```
 // 一次性设置
-actant agent create team-reviewer -t code-review --launch-mode acp-service
+actant agent create team-reviewer -t code-review --launch-mode normal
 actant agent start team-reviewer
 // Agent 持续运行，崩溃自动重启
 
@@ -694,7 +694,7 @@ Actant->Detach("ue-helper");
 | 选择 | 推荐 |
 |------|------|
 | 接入模式 | **MCP Server**（同步，#16） |
-| Agent B LaunchMode | `one-shot`（单次任务）或 `acp-service`（持久可复用） |
+| Agent B LaunchMode | `one-shot`（单次任务）或 `normal`（持久可复用） |
 
 ```
 // Agent A 的 MCP 配置中包含 Actant MCP Server
@@ -720,7 +720,7 @@ result = mcp.call("actant_prompt_agent", {
 | 选择 | 推荐 |
 |------|------|
 | 接入模式 | **Email via CLI/API**（异步，#136） |
-| Agent B/C LaunchMode | `acp-service`（雇员 Agent，主 Session 处理 Email） |
+| Agent B/C LaunchMode | `normal`（雇员 Agent，主 Session 处理 Email） |
 
 ```bash
 # 通过 CLI 发送 Email（人或 Agent 均可调用）
@@ -821,7 +821,7 @@ Agent 需要多久？
   └─ 需要持续运行
        │
        ├─ 需要 7×24 + 崩溃自动重启？
-       │    └─ 是 ──→ acp-service
+       │    └─ 是 ──→ normal
        │
        ├─ 需要用户直接交互（有 UI）？
        │    └─ 是 ──→ direct
@@ -861,7 +861,7 @@ Agent 需要多久？
                        │    │stopping│ │crashed │─────────┘         │
                        │    └───┬────┘ └────┬───┘                   │
                        │        │           │                       │
-                       │        ▼           │ (acp-service          │
+                       │        ▼           │ (normal          │
                        │    ┌────────┐      │  auto-restart)        │
                        └────│stopped │      └───────────────────────┘
                             └────────┘

--- a/.trellis/spec/api-contracts.md
+++ b/.trellis/spec/api-contracts.md
@@ -763,7 +763,7 @@ CLI 是 RPC 方法的用户端映射。每条命令内部调用对应的 RPC 方
 
 **输出格式**：`table`（默认）, `json`, `quiet`
 
-**启动模式**：`direct`, `acp-background`, `acp-service`, `one-shot`
+**启动模式**：`direct`, `acp-background`, `normal`, `one-shot`
 
 #### Agent 交互（✅ 已实现）
 

--- a/.trellis/spec/backend/logging-guidelines.md
+++ b/.trellis/spec/backend/logging-guidelines.md
@@ -41,7 +41,7 @@ logger.info("Agent launched", {
   instanceId,
   templateName,
   port,
-  launchMode: "acp-service",
+  launchMode: "normal",
 });
 ```
 

--- a/.trellis/spec/config-spec.md
+++ b/.trellis/spec/config-spec.md
@@ -343,7 +343,7 @@ Provider 存在两个层次：
 |----|--------------|------|
 | `"direct"` | 用户 | 直接打开 IDE / TUI |
 | `"acp-background"` | 调用方 | 外部客户端通过 ACP 管理 |
-| `"acp-service"` | Actant | 持久化员工 Agent，崩溃自动重启 |
+| `"normal"` | Actant | 持久化员工 Agent，崩溃自动重启 |
 | `"one-shot"` | Actant | 执行后自动终止，可选自动清理 workspace |
 
 ### WorkspacePolicy
@@ -352,7 +352,7 @@ Provider 存在两个层次：
 
 | 值 | 说明 | 典型 LaunchMode |
 |----|------|----------------|
-| `"persistent"` | workspace 持久保留，多次 spawn 复用 | `direct`, `acp-service` |
+| `"persistent"` | workspace 持久保留，多次 spawn 复用 | `direct`, `normal` |
 | `"ephemeral"` | 任务完成后可清理 workspace | `one-shot` |
 
 ### ProcessOwnership

--- a/.trellis/spec/endurance-testing.md
+++ b/.trellis/spec/endurance-testing.md
@@ -34,10 +34,10 @@
 | 场景 ID | 场景名称 | 覆盖内容 | 关停行为 |
 |---------|---------|---------|---------|
 | `E-LIFE` | 完整生命周期循环 | create → start → stop → start → stop → destroy，反复 | 显式 stop + destroy |
-| `E-SVC` | acp-service 连续崩溃重启 | 随机崩溃 → 自动重启 → 退避 → 恢复 → 重置计数器 | 崩溃后自动重启；超限后 error |
+| `E-SVC` | normal 连续崩溃重启 | 随机崩溃 → 自动重启 → 退避 → 恢复 → 重置计数器 | 崩溃后自动重启；超限后 error |
 | `E-SHOT` | one-shot 执行与清理 | 创建 → 运行 → 完成 → ephemeral 清理，反复 | 进程退出后自动销毁 |
 | `E-EXT` | 外部 Spawn 完整流程 | resolve → attach → crash/detach → cleanup，交替 ephemeral/persistent | 由调用方 detach 决定 |
-| `E-DAEMON` | Daemon 重启恢复 | Daemon 反复崩溃重启，验证 acp-service 恢复、direct 不恢复 | Daemon dispose → 新 Daemon 恢复 |
+| `E-DAEMON` | Daemon 重启恢复 | Daemon 反复崩溃重启，验证 normal 恢复、direct 不恢复 | Daemon dispose → 新 Daemon 恢复 |
 | `E-MIX` | 混合并发操作 | 多 Agent、多模式、随机 create/start/stop/crash/destroy | 各模式各自关停逻辑 |
 
 #### Phase 2: 通信与协议（待实现）
@@ -78,7 +78,7 @@
 |------------|---------|---------|---------|------------|
 | `direct` | stop → stopped | watcher 检测 → stopped | — | 恢复为 stopped（不自动重启） |
 | `acp-background` | stop → stopped | watcher 检测 → stopped | — | 恢复为 stopped |
-| `acp-service` | stop → stopped | watcher → restart (退避) | → error | 恢复为 running（自动重启） |
+| `normal` | stop → stopped | watcher → restart (退避) | → error | 恢复为 running（自动重启） |
 | `one-shot` | 进程退出 → auto-destroy | 进程退出 → auto-destroy | — | 恢复为 stopped |
 | External attach | detach → stopped | watcher → crashed | — | — |
 

--- a/.trellis/spec/frontend/directory-structure.md
+++ b/.trellis/spec/frontend/directory-structure.md
@@ -149,7 +149,7 @@ interface AgentInstanceMeta {
 }
 
 type AgentStatus = 'created' | 'starting' | 'running' | 'stopping' | 'stopped' | 'error';
-type LaunchMode = 'direct' | 'acp-background' | 'acp-service' | 'one-shot';
+type LaunchMode = 'direct' | 'acp-background' | 'normal' | 'one-shot';
 
 // template.types.ts — Agent Template 类型
 interface AgentTemplate {
@@ -742,7 +742,7 @@ Session 6: Phase 7                     → Domain Context 测试全绿 (M4)
 
 **Employee 相对常规 Agent 的增量能力**：
 
-- `launchMode: 'acp-service'` — Actant 全权管理生命周期
+- `launchMode: 'normal'` — Actant 全权管理生命周期
 - 崩溃自动重启 + 心跳健康检查
 - 长期记忆（memory plugin）
 - 定时任务（scheduler plugin）

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ shared ← core ← pi
                      │                  │   error           │
                      │                  └──────► error      │
                      │                  │                   │
-                     │              crash (acp-service)     │
+                     │              crash (normal)     │
                      │                  └── restart ──┘     │
                      │                                      │
                      └──────────── destroy ◄────────────────┘

--- a/docs/design/acp-gateway-deprecation-discussion.md
+++ b/docs/design/acp-gateway-deprecation-discussion.md
@@ -86,7 +86,7 @@
 | 驱动者 | 人类（IDE / Chat） | Daemon（调度器） |
 | 连接归属 | Proxy / Chat 持有 AcpConnection | **Daemon 持有 AcpConnection** |
 | 进程生命周期 | 跟随连接 | **长驻，持续运行** |
-| launchMode | interactive / acp-background | **acp-service** |
+| launchMode | interactive / acp-background | **normal** |
 
 **确认**：Gateway 在两种模式下都不需要。雇员型 Agent 拆为独立 Issue #37。
 

--- a/docs/design/agent-launch-scenarios.md
+++ b/docs/design/agent-launch-scenarios.md
@@ -243,7 +243,7 @@ Proxy 的翻译逻辑：
 | 驱动方 | **Daemon**（非人类） |
 | 输入来源 | Heartbeat / Cron / Webhook / Hook / Agent-to-Agent |
 | 进程生命周期 | 长驻，崩溃自动重启 |
-| launchMode | `acp-service` |
+| launchMode | `normal` |
 | 适用场景 | 7×24 运行的自主 Agent（PR 审查、监控、客服） |
 
 > 详见 [Issue #37](../../.trellis/issues/0037-employee-agent-scheduling.json)
@@ -334,7 +334,7 @@ Agent 进程由 Daemon 管理，多个客户端通过 Session Lease 交互。IDE
 | 属性 | 值 |
 |------|---|
 | 连接模式 | Session Lease |
-| launchMode | `acp-service` 或 `acp-background` |
+| launchMode | `normal` 或 `acp-background` |
 | 多 Client | 每个 Client 独立 Session |
 
 ---
@@ -357,7 +357,7 @@ actant proxy my-agent --direct     # 即使 agent 已通过 start 运行，仍�
 ### 场景 5: 雇员型 Agent
 
 ```bash
-actant agent create pr-reviewer -t pr-review --launch-mode acp-service
+actant agent create pr-reviewer -t pr-review --launch-mode normal
 actant agent start pr-reviewer
 # Agent 持续运行，Daemon 按 Heartbeat/Cron/Webhook 调度任务
 ```
@@ -365,7 +365,7 @@ actant agent start pr-reviewer
 | 属性 | 值 |
 |------|---|
 | 连接模式 | Daemon Managed |
-| launchMode | `acp-service` |
+| launchMode | `normal` |
 | 输入来源 | Heartbeat / Cron / Webhook / Hook |
 
 ---
@@ -423,9 +423,9 @@ Docker 容器中运行 Daemon + Agent，外部 IM 通过 HTTP Webhook 接入。�
 |------|---------|---------|:---:|:---:|------------|
 | 1. one-shot run | Daemon Managed | Daemon | ✗ | N/A | one-shot |
 | 2. proxy / chat（默认） | **Direct Bridge** | **Client** | **✓** | 自动实例化 | 由 Proxy 控制 |
-| 3. start + --lease | Session Lease | Daemon | ✓ | ✓ (多 Session) | acp-service/background |
+| 3. start + --lease | Session Lease | Daemon | ✓ | ✓ (多 Session) | normal/background |
 | 4. proxy --direct（显式） | Direct Bridge | Client | ✓ | 自动实例化 | 由 Proxy 控制 |
-| 5. 雇员型 | Daemon Managed | Daemon | — | — | acp-service |
+| 5. 雇员型 | Daemon Managed | Daemon | — | — | normal |
 | 6. direct IDE | 无 | 无 | N/A | N/A | direct |
 | 7. external | 外部全权 | 外部 | 外部 | 外部 | 由外部决定 |
 | 8. Web UI | Session Lease | Daemon | ✓ | ✓ | — |

--- a/docs/design/core-agent-config-roadmap.md
+++ b/docs/design/core-agent-config-roadmap.md
@@ -149,7 +149,7 @@ interface AgentInstanceMeta {
 }
 
 type AgentStatus = 'created' | 'starting' | 'running' | 'stopping' | 'stopped' | 'error';
-type LaunchMode = 'direct' | 'acp-background' | 'acp-service' | 'one-shot';
+type LaunchMode = 'direct' | 'acp-background' | 'normal' | 'one-shot';
 
 // template.types.ts — Agent Template 类型
 interface AgentTemplate {
@@ -742,7 +742,7 @@ Session 6: Phase 7                     → Domain Context 测试全绿 (M4)
 
 **Employee 相对常规 Agent 的增量能力**：
 
-- `launchMode: 'acp-service'` — Actant 全权管理生命周期
+- `launchMode: 'normal'` — Actant 全权管理生命周期
 - 崩溃自动重启 + 心跳健康检查
 - 长期记忆（memory plugin）
 - 定时任务（scheduler plugin）

--- a/docs/design/core-agent-progress-report.md
+++ b/docs/design/core-agent-progress-report.md
@@ -101,7 +101,7 @@
 |------|------|------|
 | `AgentInstanceMeta` | `agent.types.ts` | Instance 元数据：id, name, status, launchMode, pid 等 |
 | `AgentStatus` | `agent.types.ts` | 6 种状态: created/starting/running/stopping/stopped/error |
-| `LaunchMode` | `agent.types.ts` | 4 种模式: direct/acp-background/acp-service/one-shot |
+| `LaunchMode` | `agent.types.ts` | 4 种模式: direct/acp-background/normal/one-shot |
 | `AgentTemplate` | `template.types.ts` | 模板定义：backend, provider, domainContext, initializer |
 | `DomainContextConfig` | `domain-context.types.ts` | 引用配置：skills[], prompts[], mcpServers[], workflow, subAgents[] |
 | `McpServerRef` | `domain-context.types.ts` | MCP Server 内联配置：name, command, args, env |

--- a/docs/design/mvp-next-design.md
+++ b/docs/design/mvp-next-design.md
@@ -682,7 +682,7 @@ packages/core/src/scheduler/
 
 - TaskQueue：per-agent 串行队列，priority-sorted
 - TaskDispatcher：dequeue → promptAgent → record
-- AgentManager 集成：`startAgent` 时如果 launchMode=acp-service 且有 schedule，启动 dispatcher
+- AgentManager 集成：`startAgent` 时如果 launchMode=normal 且有 schedule，启动 dispatcher
 - CLI：`agent dispatch` 手动派发
 
 #### 阶段 2：InputRouter + 内置 Input Sources（#37 Phase 2）

--- a/docs/guides/ai-agent-dev-guide.md
+++ b/docs/guides/ai-agent-dev-guide.md
@@ -121,7 +121,7 @@ core/src/
 │   │   ├── process-watcher.ts           # ProcessWatcher — PID 监控
 │   │   └── backend-resolver.ts          # resolveBackend() — 后端命令解析
 │   ├── launch-mode-handler.ts           # LaunchModeHandler — 按模式处理退出/恢复
-│   └── restart-tracker.ts               # RestartTracker — acp-service 指数退避重启
+│   └── restart-tracker.ts               # RestartTracker — normal 指数退避重启
 ├── builder/
 │   ├── workspace-builder.ts             # WorkspaceBuilder — 6 步构建流水线
 │   ├── backend-builder.ts               # BackendBuilder 抽象基类, VerifyResult

--- a/docs/guides/ai-agent-usage-guide.md
+++ b/docs/guides/ai-agent-usage-guide.md
@@ -134,7 +134,7 @@ Agent 的能力由 5 类组件组合而成：
                      │                  │   error           │
                      │                  └──────► error      │
                      │                  │                   │
-                     │              crash (acp-service)     │
+                     │              crash (normal)     │
                      │                  └── restart ──┘     │
                      │                                      │
                      └──────────── destroy ◄────────────────┘
@@ -148,7 +148,7 @@ Agent 的能力由 5 类组件组合而成：
 |------|-----------|---------|---------|
 | `direct` | Daemon | 标记 stopped | 直接打开 IDE/TUI |
 | `acp-background` | Daemon + ACP | 标记 stopped | 第三方 Client 通过 ACP 管理 |
-| `acp-service` | Daemon + ACP | 自动重启（指数退避） | 持久化雇员 Agent |
+| `normal` | Daemon + ACP | 自动重启（指数退避） | 持久化雇员 Agent |
 | `one-shot` | Daemon | 标记 stopped 或自动销毁 | 执行任务后终止 |
 
 ### 3.6 通信架构
@@ -217,7 +217,7 @@ actant template install <path>          # 安装模板到 configs 目录
 actant agent create <name> -t <template>           # 基本创建
 actant agent create <name> -t <tpl> --work-dir /p  # 指定工作目录
 actant agent create <name> -t <tpl> --workspace /p # 指定外部工作区
-actant agent create <name> -t <tpl> --launch-mode acp-service  # 指定启动模式
+actant agent create <name> -t <tpl> --launch-mode normal  # 指定启动模式
 actant agent create <name> -t <tpl> --overwrite    # 覆盖已有实例
 actant agent create <name> -t <tpl> --append       # 追加到已有工作区
 
@@ -395,7 +395,7 @@ actant agent list
 
 ```bash
 actant template load ./daily-reviewer.json
-actant agent create reviewer -t daily-reviewer --launch-mode acp-service
+actant agent create reviewer -t daily-reviewer --launch-mode normal
 actant agent start reviewer
 actant schedule list reviewer    # 查看调度状态
 ```

--- a/docs/planning/archive/phase3c-employee-scheduler.md
+++ b/docs/planning/archive/phase3c-employee-scheduler.md
@@ -53,7 +53,7 @@ isProject: false
 
 - `employee-scheduler.ts` — 编排 InputRouter + TaskQueue + Dispatcher
 - `template-schema.ts` — 新增 ScheduleConfigSchema
-- `agent-manager.ts` — acp-service 模式 + schedule 配置 → 启动 scheduler
+- `agent-manager.ts` — normal 模式 + schedule 配置 → 启动 scheduler
 - RPC handlers: agent.dispatch / agent.tasks / agent.logs
 
 ## Todo 4: CLI + Webhook/N8N

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -65,7 +65,7 @@ Actant 同时扮演：
 | #23 | LaunchMode 行为分化 | P0 | #22 | ✅ 完成 |
 | #26 | agent.resolve / agent.attach / agent.detach API | P1 | #22, #23 | ✅ 完成 |
 | #24 | one-shot 模式完整实现 | P1 | #22, #23 | ✅ 完成 |
-| #25 | acp-service 崩溃重启策略 | P1 | #22 | ✅ 完成 |
+| #25 | normal 崩溃重启策略 | P1 | #22 | ✅ 完成 |
 
 ---
 
@@ -410,7 +410,7 @@ Phase 1、Phase 2 MVP、Phase 3 核心三线（3a/3b/3c）全部完成。#104/#1
 | 功能 | 实现内容 |
 |------|---------|
 | ProcessWatcher | 定时轮询 PID 存活检测、退出事件回调、与 AgentManager 集成 |
-| LaunchMode 分化 | Handler 模式：direct/acp-background/acp-service/one-shot 各有独立的退出行为和恢复策略 |
+| LaunchMode 分化 | Handler 模式：direct/acp-background/normal/one-shot 各有独立的退出行为和恢复策略 |
 | 外部 Spawn | resolve/attach/detach 完整 API + RPC handler + CLI 命令，支持 metadata 传递 |
 | One-shot 模式 | autoDestroy 自动销毁、ephemeral workspace 策略、WorkspacePolicy 类型系统 |
 | 崩溃重启 | 指数退避 RestartTracker、最大重试限制、daemon 重启恢复、稳定期自动重置计数器 |
@@ -508,7 +508,7 @@ Phase 1、Phase 2 MVP、Phase 3 核心三线（3a/3b/3c）全部完成。#104/#1
 | #22 | ProcessWatcher：进程退出检测与心跳监控 | 2026-02-20 | Phase 1 |
 | #23 | LaunchMode 行为分化 | 2026-02-20 | Phase 1 |
 | #24 | one-shot 模式完整实现 | 2026-02-20 | Phase 1 |
-| #25 | acp-service 崩溃重启策略 | 2026-02-20 | Phase 1 |
+| #25 | normal 崩溃重启策略 | 2026-02-20 | Phase 1 |
 | #26 | agent.resolve / attach / detach API — 外部 Spawn 支持 | 2026-02-20 | Phase 1 |
 | #5 | CLI 包测试覆盖率为零 — 补充单元测试 | 2026-02-20 | Phase 1 (质量) |
 | #6 | CLI 包 console.log 违反质量规范 — 引入 CliPrinter 结构化输出层 | 2026-02-20 | Phase 1 (质量) |
@@ -547,7 +547,7 @@ Phase 1、Phase 2 MVP、Phase 3 核心三线（3a/3b/3c）全部完成。#104/#1
  │     └──→ [Phase 2 MVP] #13 ACP Client 简化版
  │     └──→ [Phase 2 MVP] #112 Domain Context 全链路
  │
- ├──→ #25 acp-service 崩溃重启 (P1) ✅
+ ├──→ #25 normal 崩溃重启 (P1) ✅
  └──→ [Phase 4] #14 Plugin 体系 (P2)
 
 

--- a/docs/reports/PROJECT_ANALYSIS_REPORT.md
+++ b/docs/reports/PROJECT_ANALYSIS_REPORT.md
@@ -198,11 +198,11 @@ async createAgent(name: string, templateName: string, ...)
 
 ```typescript
 // 已实现
-export type LaunchMode = "direct" | "acp-background" | "acp-service" | "one-shot";
+export type LaunchMode = "direct" | "acp-background" | "normal" | "one-shot";
 ```
 
 - **direct**: 直接打开 IDE（已实现 MockLauncher）
-- **acp-service**: 后台服务（AgentManager 支持）
+- **normal**: 后台服务（AgentManager 支持）
 - **one-shot**: 一次性任务（元数据支持）
 - **acp-background**: ACP 后台模式（待实现）
 

--- a/packages/cli/src/commands/agent/create.ts
+++ b/packages/cli/src/commands/agent/create.ts
@@ -7,7 +7,7 @@ import type { LaunchMode, WorkDirConflict } from "@actant/shared";
 import type { RpcClient } from "../../client/rpc-client";
 import { presentError, formatAgentDetail, type OutputFormat, type CliPrinter, defaultPrinter } from "../../output/index";
 
-const VALID_LAUNCH_MODES = new Set(["direct", "acp-background", "acp-service", "one-shot"]);
+const VALID_LAUNCH_MODES = new Set(["direct", "acp-background", "normal", "one-shot"]);
 
 function askQuestion(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -24,7 +24,7 @@ export function createAgentCreateCommand(client: RpcClient, printer: CliPrinter 
     .description("Create a new agent from a template")
     .argument("<name>", "Agent instance name")
     .requiredOption("-t, --template <template>", "Template name to use")
-    .option("--launch-mode <mode>", "Launch mode: direct, acp-background, acp-service, one-shot")
+    .option("--launch-mode <mode>", "Launch mode: direct, acp-background, normal, one-shot")
     .option("--work-dir <path>", "Custom workspace directory (absolute or relative path)")
     .option("--workspace <path>", "Same as --work-dir: create instance at external path instead of builtin location")
     .option("--overwrite", "If instance directory exists, remove it and recreate")

--- a/packages/core/src/initializer/agent-initializer.test.ts
+++ b/packages/core/src/initializer/agent-initializer.test.ts
@@ -126,10 +126,10 @@ describe("AgentInitializer", () => {
 
     it("should use defaultLaunchMode from options when no override", async () => {
       initializer = new AgentInitializer(registry, tmpDir, {
-        defaultLaunchMode: "acp-service",
+        defaultLaunchMode: "normal",
       });
       const meta = await initializer.createInstance("my-agent", "test-template");
-      expect(meta.launchMode).toBe("acp-service");
+      expect(meta.launchMode).toBe("normal");
     });
 
     it("should default workspacePolicy to persistent for non-one-shot modes", async () => {

--- a/packages/core/src/manager/agent-lifecycle-scenarios.test.ts
+++ b/packages/core/src/manager/agent-lifecycle-scenarios.test.ts
@@ -93,14 +93,14 @@ describe("Agent lifecycle scenarios", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  describe("Scenario: acp-service continuous crash-restart cycle", () => {
+  describe("Scenario: normal continuous crash-restart cycle", () => {
     it("should restart on crash, backoff, then give up after max retries", async () => {
       const manager = createWatcherManager(initializer, launcher, tmpDir, {
         restartMaxRestarts: 2,
       });
       await manager.initialize();
 
-      await manager.createAgent("svc", "test-tpl", { launchMode: "acp-service" });
+      await manager.createAgent("svc", "test-tpl", { launchMode: "normal" });
       await manager.startAgent("svc");
       expect(manager.getStatus("svc")).toBe("running");
       const pid0 = manager.getAgent("svc")!.pid!;
@@ -282,12 +282,12 @@ describe("Agent lifecycle scenarios", () => {
   });
 
   describe("Scenario: daemon restart recovery", () => {
-    it("should recover acp-service agents after daemon restart", async () => {
-      // Phase A: create and start an acp-service agent, then "crash" the daemon
+    it("should recover normal agents after daemon restart", async () => {
+      // Phase A: create and start an normal agent, then "crash" the daemon
       const manager1 = createWatcherManager(initializer, launcher, tmpDir);
       await manager1.initialize();
 
-      await manager1.createAgent("employee", "test-tpl", { launchMode: "acp-service" });
+      await manager1.createAgent("employee", "test-tpl", { launchMode: "normal" });
       await manager1.startAgent("employee");
       expect(manager1.getStatus("employee")).toBe("running");
       expect(manager1.getAgent("employee")?.pid).toBeDefined();
@@ -299,7 +299,7 @@ describe("Agent lifecycle scenarios", () => {
       const manager2 = createWatcherManager(initializer, launcher, tmpDir);
       await manager2.initialize();
 
-      // acp-service should have been auto-recovered to running
+      // normal should have been auto-recovered to running
       await vi.waitFor(() => {
         expect(manager2.getStatus("employee")).toBe("running");
       }, { timeout: 3000, interval: 50 });
@@ -337,7 +337,7 @@ describe("Agent lifecycle scenarios", () => {
       });
       await manager.initialize();
 
-      await manager.createAgent("svc-a", "test-tpl", { launchMode: "acp-service" });
+      await manager.createAgent("svc-a", "test-tpl", { launchMode: "normal" });
       await manager.createAgent("direct-b", "test-tpl", { launchMode: "direct" });
       await manager.createAgent("oneshot-c", "test-tpl", {
         launchMode: "one-shot",
@@ -353,7 +353,7 @@ describe("Agent lifecycle scenarios", () => {
       const pidDirect = manager.getAgent("direct-b")!.pid!;
       const pidOneshot = manager.getAgent("oneshot-c")!.pid!;
 
-      // Kill specific PIDs so the restarted acp-service gets a fresh live PID
+      // Kill specific PIDs so the restarted normal gets a fresh live PID
       const ctl = await createPidController();
       ctl.kill(pidSvc);
       ctl.kill(pidDirect);
@@ -365,7 +365,7 @@ describe("Agent lifecycle scenarios", () => {
         expect(manager.getStatus("svc-a")).toBe("running");
       }, { timeout: 5000, interval: 50 });
 
-      // acp-service got a new PID
+      // normal got a new PID
       expect(manager.getAgent("svc-a")?.pid).not.toBe(pidSvc);
       expect(manager.size).toBe(2);
 

--- a/packages/core/src/manager/agent-manager.endurance.test.ts
+++ b/packages/core/src/manager/agent-manager.endurance.test.ts
@@ -183,13 +183,13 @@ describe("Endurance tests — Phase 1", () => {
     console.log(`[endurance] E-LIFE: ${cycles} cycles in ${Date.now() - startTime}ms`);
   });
 
-  // ── E-SVC: acp-service 连续崩溃重启 ──────────────────────────────────
+  // ── E-SVC: normal 连续崩溃重启 ──────────────────────────────────
 
-  it(`E-SVC: acp-service crash/restart — ${DURATION_MS}ms`, async () => {
+  it(`E-SVC: normal crash/restart — ${DURATION_MS}ms`, async () => {
     const manager = new AgentManager(initializer, launcher, tmpDir, makeManagerOpts());
     await manager.initialize();
 
-    await manager.createAgent("svc", "test-tpl", { launchMode: "acp-service" });
+    await manager.createAgent("svc", "test-tpl", { launchMode: "normal" });
     await manager.startAgent("svc");
 
     const ctl = await createPidController();
@@ -378,11 +378,11 @@ describe("Endurance tests — Phase 1", () => {
       const manager = new AgentManager(initializer, launcher, tmpDir, opts);
       await manager.initialize();
 
-      // Ensure one acp-service and one direct agent exist and run
+      // Ensure one normal and one direct agent exist and run
       const svcName = "daemon-svc";
       const directName = "daemon-direct";
 
-      for (const [name, mode] of [[svcName, "acp-service"], [directName, "direct"]] as const) {
+      for (const [name, mode] of [[svcName, "normal"], [directName, "direct"]] as const) {
         if (!manager.getAgent(name)) {
           await manager.createAgent(name, "test-tpl", { launchMode: mode });
         }
@@ -409,7 +409,7 @@ describe("Endurance tests — Phase 1", () => {
       const manager2 = new AgentManager(initializer, launcher, tmpDir, opts);
       await manager2.initialize();
 
-      // acp-service → auto-restarted → running
+      // normal → auto-restarted → running
       expect(manager2.getStatus(svcName)).toBe("running");
       expect(manager2.getAgent(svcName)?.pid).toBeDefined();
 
@@ -451,7 +451,7 @@ describe("Endurance tests — Phase 1", () => {
 
       if (action < 0.25 && agentNames.size < 20) {
         const name = `mix-${nextId++}`;
-        const mode = (["direct", "acp-service", "one-shot"] as const)[randomInt(0, 2)];
+        const mode = (["direct", "normal", "one-shot"] as const)[randomInt(0, 2)];
         try {
           await manager.createAgent(name, "test-tpl", { launchMode: mode });
           agentNames.add(name);
@@ -619,7 +619,7 @@ describe("Endurance tests — Phase 1", () => {
       console.log(`[endurance] shutdown/one-shot-ephemeral: ${cycles} cycles in ${Date.now() - startTime}ms`);
     });
 
-    it(`acp-service: crash → restart, stop → no restart — ${DURATION_MS}ms`, async () => {
+    it(`normal: crash → restart, stop → no restart — ${DURATION_MS}ms`, async () => {
       const manager = new AgentManager(initializer, launcher, tmpDir, makeManagerOpts());
       await manager.initialize();
       const ctl = await createPidController();
@@ -628,7 +628,7 @@ describe("Endurance tests — Phase 1", () => {
       let cleanStops = 0;
       const startTime = Date.now();
 
-      await manager.createAgent("svc-sh", "test-tpl", { launchMode: "acp-service" });
+      await manager.createAgent("svc-sh", "test-tpl", { launchMode: "normal" });
       await manager.startAgent("svc-sh");
 
       while (Date.now() - startTime < DURATION_MS) {
@@ -662,7 +662,7 @@ describe("Endurance tests — Phase 1", () => {
       ctl.restore();
       manager.dispose();
 
-      console.log(`[endurance] shutdown/acp-service: ${crashRestarts} crash-restarts, ${cleanStops} clean-stops in ${Date.now() - startTime}ms`);
+      console.log(`[endurance] shutdown/normal: ${crashRestarts} crash-restarts, ${cleanStops} clean-stops in ${Date.now() - startTime}ms`);
     });
 
     it(`external attach: crash → crashed (not stopped), detach → ownership reset — ${DURATION_MS}ms`, async () => {

--- a/packages/core/src/manager/agent-manager.test.ts
+++ b/packages/core/src/manager/agent-manager.test.ts
@@ -255,14 +255,14 @@ describe("AgentManager", () => {
   });
 
   describe("LaunchMode behavior", () => {
-    it("should auto-restart acp-service agent on crash", async () => {
+    it("should auto-restart normal-mode agent on crash", async () => {
       const watcherManager = new AgentManager(initializer, launcher, tmpDir, {
         watcherPollIntervalMs: 50,
         restartPolicy: { backoffBaseMs: 10, backoffMaxMs: 50 },
       });
       await watcherManager.initialize();
 
-      await watcherManager.createAgent("svc-agent", "test-tpl", { launchMode: "acp-service" });
+      await watcherManager.createAgent("svc-agent", "test-tpl", { launchMode: "normal" });
       await watcherManager.startAgent("svc-agent");
       expect(watcherManager.getStatus("svc-agent")).toBe("running");
       const firstPid = watcherManager.getAgent("svc-agent")?.pid;
@@ -284,13 +284,13 @@ describe("AgentManager", () => {
       watcherManager.dispose();
     });
 
-    it("should recover acp-service agent on daemon restart", async () => {
+    it("should recover normal-mode agent on daemon restart", async () => {
       const dir = join(tmpDir, "svc-stale");
       await mkdir(dir);
       await writeInstanceMeta(dir, makeMeta("svc-stale", {
         status: "running",
         pid: 99999,
-        launchMode: "acp-service",
+        launchMode: "normal",
       }));
 
       const newManager = new AgentManager(initializer, launcher, tmpDir, {
@@ -298,21 +298,21 @@ describe("AgentManager", () => {
       });
       await newManager.initialize();
 
-      // acp-service should attempt restart: status should be running
+      // normal-mode should attempt restart: status should be running
       expect(newManager.getStatus("svc-stale")).toBe("running");
       expect(newManager.getAgent("svc-stale")?.pid).toBeDefined();
 
       newManager.dispose();
     });
 
-    it("should mark acp-service agent as error after restart limit exceeded", async () => {
+    it("should mark normal-mode agent as error after restart limit exceeded", async () => {
       const watcherManager = new AgentManager(initializer, launcher, tmpDir, {
         watcherPollIntervalMs: 50,
         restartPolicy: { maxRestarts: 1, backoffBaseMs: 5, backoffMaxMs: 10 },
       });
       await watcherManager.initialize();
 
-      await watcherManager.createAgent("svc-limit", "test-tpl", { launchMode: "acp-service" });
+      await watcherManager.createAgent("svc-limit", "test-tpl", { launchMode: "normal" });
       await watcherManager.startAgent("svc-limit");
 
       const processUtils = await import("./launcher/process-utils");

--- a/packages/core/src/manager/agent-manager.ts
+++ b/packages/core/src/manager/agent-manager.ts
@@ -61,7 +61,7 @@ export interface ManagerOptions {
   corruptedDir?: string;
   /** Milliseconds between process alive checks. Default: 5000 */
   watcherPollIntervalMs?: number;
-  /** Restart policy for acp-service agents. */
+  /** Restart policy for normal-mode agents. */
   restartPolicy?: Partial<RestartPolicy>;
   /** ACP connection manager for ACP-based backends. */
   acpManager?: AcpConnectionManagerLike;

--- a/packages/core/src/manager/launch-mode-handler.test.ts
+++ b/packages/core/src/manager/launch-mode-handler.test.ts
@@ -45,8 +45,8 @@ describe("LaunchModeHandler", () => {
     });
   });
 
-  describe("acp-service", () => {
-    const handler = getLaunchModeHandler("acp-service");
+  describe("normal", () => {
+    const handler = getLaunchModeHandler("normal");
 
     it("should return restart on process exit", () => {
       expect(handler.getProcessExitAction("agent-1")).toEqual({ type: "restart" });
@@ -81,12 +81,12 @@ describe("LaunchModeHandler", () => {
 
   describe("getLaunchModeHandler", () => {
     it("should return different handlers for each mode", () => {
-      const modes = ["direct", "acp-background", "acp-service", "one-shot"] as const;
+      const modes = ["direct", "acp-background", "normal", "one-shot"] as const;
       const handlers = modes.map(getLaunchModeHandler);
 
       expect(handlers[0]!.mode).toBe("direct");
       expect(handlers[1]!.mode).toBe("acp-background");
-      expect(handlers[2]!.mode).toBe("acp-service");
+      expect(handlers[2]!.mode).toBe("normal");
       expect(handlers[3]!.mode).toBe("one-shot");
     });
   });

--- a/packages/core/src/manager/launch-mode-handler.ts
+++ b/packages/core/src/manager/launch-mode-handler.ts
@@ -6,7 +6,7 @@ const logger = createLogger("launch-mode-handler");
 /**
  * What the manager should do when a watched process exits.
  * - "mark-stopped": set status to stopped, clear pid (default for most modes)
- * - "restart": attempt to relaunch the process (acp-service with restart policy)
+ * - "restart": attempt to relaunch the process (normal mode with restart policy)
  * - "destroy": mark stopped then destroy the instance (one-shot with autoDestroy)
  */
 export type ProcessExitAction =
@@ -17,7 +17,7 @@ export type ProcessExitAction =
 /**
  * What the manager should do for a stale running/starting instance on daemon restart.
  * - "mark-stopped": reset status to stopped (default)
- * - "restart": attempt to relaunch (acp-service recovery)
+ * - "restart": attempt to relaunch (normal mode recovery)
  */
 export type RecoveryAction =
   | { type: "mark-stopped" }
@@ -53,16 +53,16 @@ class AcpBackgroundModeHandler implements LaunchModeHandler {
   }
 }
 
-class AcpServiceModeHandler implements LaunchModeHandler {
-  readonly mode = "acp-service" as const;
+class NormalModeHandler implements LaunchModeHandler {
+  readonly mode = "normal" as const;
 
   getProcessExitAction(instanceName: string): ProcessExitAction {
-    logger.info({ instanceName }, "acp-service process exited — restart policy will be checked");
+    logger.info({ instanceName }, "normal-mode process exited — restart policy will be checked");
     return { type: "restart" };
   }
 
   getRecoveryAction(instanceName: string): RecoveryAction {
-    logger.info({ instanceName }, "acp-service stale instance — will attempt recovery restart");
+    logger.info({ instanceName }, "normal-mode stale instance — will attempt recovery restart");
     return { type: "restart" };
   }
 }
@@ -85,7 +85,7 @@ class OneShotModeHandler implements LaunchModeHandler {
 const handlers: Record<LaunchMode, LaunchModeHandler> = {
   "direct": new DirectModeHandler(),
   "acp-background": new AcpBackgroundModeHandler(),
-  "acp-service": new AcpServiceModeHandler(),
+  "normal": new NormalModeHandler(),
   "one-shot": new OneShotModeHandler(),
 };
 

--- a/packages/core/src/state/instance-meta-schema.ts
+++ b/packages/core/src/state/instance-meta-schema.ts
@@ -13,7 +13,7 @@ export const AgentStatusSchema = z.enum([
 export const LaunchModeSchema = z.enum([
   "direct",
   "acp-background",
-  "acp-service",
+  "normal",
   "one-shot",
 ]);
 

--- a/packages/shared/src/types/agent.types.ts
+++ b/packages/shared/src/types/agent.types.ts
@@ -48,7 +48,7 @@ export type AgentStatus =
 export type LaunchMode =
   | "direct"
   | "acp-background"
-  | "acp-service"
+  | "normal"
   | "one-shot";
 
 export type ProcessOwnership = "managed" | "external";


### PR DESCRIPTION
## Summary

Rename the `"acp-service"` launch mode to `"normal"` across the entire codebase, as requested in #154. The previous name was overly implementation-specific and didn't convey the intended semantics — `"normal"` better represents the standard, persistent agent execution mode with auto-restart behavior.

## Changes

### Type System & Schema (3 files)
- **`packages/shared/src/types/agent.types.ts`** — Updated `LaunchMode` union type: `"acp-service"` → `"normal"`
- **`packages/core/src/state/instance-meta-schema.ts`** — Updated `LaunchModeSchema` Zod enum
- **`packages/core/src/manager/launch-mode-handler.ts`** — Renamed `AcpServiceModeHandler` → `NormalModeHandler`, updated log messages

### CLI (1 file)
- **`packages/cli/src/commands/agent/create.ts`** — Updated `VALID_LAUNCH_MODES` set and `--launch-mode` help text

### Manager (1 file)
- **`packages/core/src/manager/agent-manager.ts`** — Updated JSDoc comment for restart policy

### Tests (5 files)
- `launch-mode-handler.test.ts` — All test cases and assertions updated
- `agent-manager.test.ts` — 3 test cases renamed and updated
- `agent-manager.endurance.test.ts` — All endurance test references updated
- `agent-lifecycle-scenarios.test.ts` — All lifecycle scenario references updated
- `agent-initializer.test.ts` — Default launch mode test updated

### Documentation & Specs (17 files)
- **Trellis specs**: `agent-lifecycle.md`, `config-spec.md`, `api-contracts.md`, `endurance-testing.md`, `logging-guidelines.md`, `directory-structure.md`
- **Design docs**: `agent-launch-scenarios.md`, `mvp-next-design.md`, `core-agent-config-roadmap.md`, `core-agent-progress-report.md`, `acp-gateway-deprecation-discussion.md`
- **Guides**: `ai-agent-usage-guide.md`, `ai-agent-dev-guide.md`
- **Planning**: `roadmap.md`, `phase3c-employee-scheduler.md`
- **Other**: `README.md`, `PROJECT_ANALYSIS_REPORT.md`
- **Issues**: `0153-instance-interaction-archetype.md` (archetype proposal references)

> Note: Historical version snapshots under `docs/stage/` were intentionally left unchanged.

## Verification

- TypeScript type-check passes (`@actant/shared` + `@actant/core`)
- All 11 launch-mode-handler unit tests pass
- No remaining `acp-service` references in `.ts` source files

## Impact

- **Breaking change for persisted data**: Existing `.actant.json` files with `"launchMode": "acp-service"` will fail Zod validation. A migration note or backward-compatible fallback may be needed for production deployments.
- **CLI**: Users must now use `--launch-mode normal` instead of `--launch-mode acp-service`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
