### PR TITLE
refactor: replace domain context contracts with project context

### DIFF
--- a/.trellis/scripts/diff-versions.mjs
+++ b/.trellis/scripts/diff-versions.mjs
@@ -69,6 +69,13 @@ function diffFields(oldFields, newFields) {
   return diffArrayByKey(oldFields || [], newFields || [], f => f.name);
 }
 
+function getTypeInterfaceGroup(config, groupKey) {
+  if (groupKey === "projectContext") {
+    return config.typeInterfaces.projectContext || config.typeInterfaces.domainContext || [];
+  }
+  return config.typeInterfaces[groupKey] || [];
+}
+
 async function main() {
   const [api1, api2, cfg1, cfg2] = await Promise.all([
     loadJson(v1, "api-surface.json"),
@@ -300,9 +307,9 @@ async function main() {
     w("## 6. TypeScript 接口变更");
     w("");
 
-    for (const groupKey of ["agent", "template", "domainContext", "domainComponent", "source"]) {
-      const old = cfg1.typeInterfaces[groupKey] || [];
-      const cur = cfg2.typeInterfaces[groupKey] || [];
+    for (const groupKey of ["agent", "template", "projectContext", "domainComponent", "source"]) {
+      const old = getTypeInterfaceGroup(cfg1, groupKey);
+      const cur = getTypeInterfaceGroup(cfg2, groupKey);
       const diff = diffArrayByKey(old, cur, i => i.name);
 
       if (diff.added.length || diff.removed.length || diff.modified.length) {

--- a/.trellis/scripts/gen-surface-snapshot.mjs
+++ b/.trellis/scripts/gen-surface-snapshot.mjs
@@ -18,7 +18,7 @@
  * Usage: node gen-surface-snapshot.mjs <output-dir>
  */
 
-import { readFile, writeFile, readdir } from "node:fs/promises";
+import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,12 +34,12 @@ const PATHS = {
   rpcTypes: join(ROOT, "packages/shared/src/types/rpc.types.ts"),
   agentTypes: join(ROOT, "packages/shared/src/types/agent.types.ts"),
   templateTypes: join(ROOT, "packages/shared/src/types/template.types.ts"),
-  domainContextTypes: join(ROOT, "packages/shared/src/types/domain-context.types.ts"),
+  projectContextTypes: join(ROOT, "packages/shared/src/types/project-context.types.ts"),
   domainComponentTypes: join(ROOT, "packages/shared/src/types/domain-component.types.ts"),
   sourceTypes: join(ROOT, "packages/shared/src/types/source.types.ts"),
-  templateSchema: join(ROOT, "packages/core/src/template/schema/template-schema.ts"),
-  instanceMetaSchema: join(ROOT, "packages/core/src/state/instance-meta-schema.ts"),
-  scheduleConfigSchema: join(ROOT, "packages/core/src/scheduler/schedule-config.ts"),
+  templateSchema: join(ROOT, "packages/domain-context/src/template/schema/template-schema.ts"),
+  instanceMetaSchema: join(ROOT, "packages/agent-runtime/src/state/instance-meta-schema.ts"),
+  scheduleConfigSchema: join(ROOT, "packages/domain-context/src/schemas/schedule-config.ts"),
   cliCommands: join(ROOT, "packages/cli/src/commands"),
   program: join(ROOT, "packages/cli/src/program.ts"),
 };
@@ -281,13 +281,14 @@ function extractErrorCodes(source) {
 
 async function main() {
   console.log("Generating API surface & config schema snapshots...");
+  await mkdir(outputDir, { recursive: true });
 
   // --- Read all source files ---
-  const [rpcSrc, agentSrc, templateTypeSrc, domainCtxSrc, domainCompSrc, sourceSrc, templateSchemaSrc, metaSchemaSrc, scheduleSchemaSrc] = await Promise.all([
+  const [rpcSrc, agentSrc, templateTypeSrc, projectContextSrc, domainCompSrc, sourceSrc, templateSchemaSrc, metaSchemaSrc, scheduleSchemaSrc] = await Promise.all([
     readFile(PATHS.rpcTypes, "utf8"),
     readFile(PATHS.agentTypes, "utf8"),
     readFile(PATHS.templateTypes, "utf8"),
-    readFile(PATHS.domainContextTypes, "utf8"),
+    readFile(PATHS.projectContextTypes, "utf8"),
     readFile(PATHS.domainComponentTypes, "utf8"),
     readFile(PATHS.sourceTypes, "utf8"),
     readFile(PATHS.templateSchema, "utf8"),
@@ -304,7 +305,7 @@ async function main() {
   const agentInterfaces = extractInterfaces(agentSrc);
   const agentEnums = extractEnums(agentSrc);
   const templateInterfaces = extractInterfaces(templateTypeSrc);
-  const domainCtxInterfaces = extractInterfaces(domainCtxSrc);
+  const projectContextInterfaces = extractInterfaces(projectContextSrc);
   const domainCompInterfaces = extractInterfaces(domainCompSrc);
   const sourceInterfaces = extractInterfaces(sourceSrc);
 
@@ -345,7 +346,7 @@ async function main() {
     typeInterfaces: {
       agent: agentInterfaces,
       template: templateInterfaces,
-      domainContext: domainCtxInterfaces,
+      projectContext: projectContextInterfaces,
       domainComponent: domainCompInterfaces,
       source: sourceInterfaces,
     },
@@ -368,7 +369,7 @@ async function main() {
 
   console.log(`✓ api-surface.md    (${rpcMethods.length} RPC methods, ${apiJson.cli.totalSubcommands} CLI commands)`);
   console.log(`✓ api-surface.json`);
-  console.log(`✓ config-schemas.md (${templateSchemas.length + metaSchemas.length + scheduleSchemas.length} Zod schemas, ${agentInterfaces.length + templateInterfaces.length + domainCtxInterfaces.length + domainCompInterfaces.length + sourceInterfaces.length} interfaces)`);
+  console.log(`✓ config-schemas.md (${templateSchemas.length + metaSchemas.length + scheduleSchemas.length} Zod schemas, ${agentInterfaces.length + templateInterfaces.length + projectContextInterfaces.length + domainCompInterfaces.length + sourceInterfaces.length} interfaces)`);
   console.log(`✓ config-schemas.json`);
   console.log(`  Output: ${outputDir}`);
 }
@@ -553,7 +554,7 @@ function generateConfigMd(config) {
   const ifaceGroups = [
     ["Agent 实例类型", config.typeInterfaces.agent],
     ["Template 模板类型", config.typeInterfaces.template],
-    ["DomainContext 领域上下文", config.typeInterfaces.domainContext],
+    ["ProjectContext 项目上下文", config.typeInterfaces.projectContext],
     ["DomainComponent 领域组件", config.typeInterfaces.domainComponent],
     ["Source 组件源", config.typeInterfaces.source],
   ];

--- a/.trellis/spec/config-spec.md
+++ b/.trellis/spec/config-spec.md
@@ -15,6 +15,10 @@
 
 旧模板聚合配置、旧 DomainContext 聚合配置若仍存在于代码中，当前视为历史实现遗留，不作为新的规范入口。
 
+M1 契约替换期间，仓库中的 agent template / workspace materialization 接口统一使用 `project` 字段表达项目级资源选择。
+它只表示当前 agent workspace 需要装配哪些 skills、prompts、MCP servers、plugins 等资源引用，
+不重新引入旧 `DomainContext` 作为新的默认配置真相。
+
 ---
 
 ## 2. ProjectManifest

--- a/.trellis/spec/terminology.md
+++ b/.trellis/spec/terminology.md
@@ -123,6 +123,7 @@ Permission 表示当前 caller“能不能执行该操作”。
 - `ContextFS`
 - `VFS Kernel`
 - `Project`
+- `ProjectContext`
 - `ProjectManifest`
 - `Source`
 - `Capability`
@@ -176,6 +177,7 @@ Permission 表示当前 caller“能不能执行该操作”。
 优先使用：
 
 - `AgentRuntime`
+- `ProjectContext`
 - `Control Node`
 - `Stream Node`
 - `Session`

--- a/configs/templates/code-review-agent.json
+++ b/configs/templates/code-review-agent.json
@@ -14,7 +14,7 @@
       "apiKeyEnv": "ANTHROPIC_API_KEY"
     }
   },
-  "domainContext": {
+  "project": {
     "skills": ["code-review", "typescript-expert"],
     "prompts": ["system-code-reviewer"],
     "mcpServers": [

--- a/examples/actant-hub/templates/actant-curator.json
+++ b/examples/actant-hub/templates/actant-curator.json
@@ -4,7 +4,7 @@
   "description": "Actant 资产管家 — 记忆治理 + 托管资产管理 + 运行记录归档。一切即 file。",
   "archetype": "employee",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "memory-governance",
       "asset-registry",

--- a/examples/actant-hub/templates/actant-maintainer.json
+++ b/examples/actant-hub/templates/actant-maintainer.json
@@ -4,7 +4,7 @@
   "description": "Actant 维护者 — 自修复 + 自进化免疫系统。监控健康、诊断问题、自动修复、生成进化报告。",
   "archetype": "employee",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "self-diagnosis",
       "self-repair",

--- a/examples/actant-hub/templates/actant-onboarder.json
+++ b/examples/actant-hub/templates/actant-onboarder.json
@@ -4,7 +4,7 @@
   "description": "Actant 引导员 — 新用户引导 + 交互式教学。帮助用户快速上手 Actant 平台。",
   "archetype": "tool",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "guided-setup",
       "interactive-tutorial",

--- a/examples/actant-hub/templates/actant-researcher.json
+++ b/examples/actant-hub/templates/actant-researcher.json
@@ -4,7 +4,7 @@
   "description": "Actant 研究员 — 信息检索 + 知识采集。为其他 Agent 和人类提供外部知识支持。",
   "archetype": "service",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "web-research",
       "knowledge-synthesis",

--- a/examples/actant-hub/templates/actant-scavenger.json
+++ b/examples/actant-hub/templates/actant-scavenger.json
@@ -4,7 +4,7 @@
   "description": "Actant 清道夫 — 垃圾清理 + 资源回收。维护系统整洁，释放磁盘和内存资源。",
   "archetype": "employee",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "resource-scan",
       "cleanup-policy",

--- a/examples/actant-hub/templates/actant-spark.json
+++ b/examples/actant-hub/templates/actant-spark.json
@@ -4,7 +4,7 @@
   "description": "Actant 火种 — 自主 fork、持续编码、PR 回馈主线。永不停止的贡献者 Agent。",
   "archetype": "employee",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "code-generation",
       "pr-management",

--- a/examples/actant-hub/templates/actant-steward.json
+++ b/examples/actant-hub/templates/actant-steward.json
@@ -4,7 +4,7 @@
   "description": "Actant 管家 — 人类唯一入口，替代 CLI。理解意图、路由任务、汇报结果。",
   "archetype": "service",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "intent-routing",
       "conversation-management",

--- a/examples/actant-hub/templates/actant-updater.json
+++ b/examples/actant-hub/templates/actant-updater.json
@@ -4,7 +4,7 @@
   "description": "Actant 升级者 — 版本升级 + 数据迁移 + Hub 源同步。确保系统始终运行在最佳版本。",
   "archetype": "employee",
   "backend": { "type": "claude-code" },
-  "domainContext": {
+  "project": {
     "skills": [
       "version-check",
       "migration-engine",

--- a/examples/project-context-bootstrap/configs/templates/project-context-agent.json
+++ b/examples/project-context-bootstrap/configs/templates/project-context-agent.json
@@ -8,7 +8,7 @@
   "provider": {
     "type": "anthropic"
   },
-  "domainContext": {
+  "project": {
     "skills": ["project-context-reader"],
     "prompts": ["project-context-bootstrap"]
   }

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -41,7 +41,6 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@actant/context": "workspace:0.5.0",
     "@actant/domain-context": "workspace:0.5.0",
     "@actant/shared": "workspace:0.5.0",
     "@actant/source": "workspace:0.5.0",

--- a/packages/agent-runtime/src/builder/component-type-handler.ts
+++ b/packages/agent-runtime/src/builder/component-type-handler.ts
@@ -2,11 +2,11 @@ import type { AgentBackendType } from "@actant/shared";
 import type { BaseComponentManager, NamedComponent } from "@actant/domain-context";
 
 /**
- * Encapsulates the handling of a single DomainContext component type.
+ * Encapsulates the handling of a single project component type.
  * Each handler knows how to resolve names and materialize definitions.
  */
 export interface ComponentTypeHandler<TDef = unknown> {
-  /** The key in DomainContextConfig (e.g. "skills", "prompts") */
+  /** The key in ProjectContextConfig (e.g. "skills", "prompts") */
   readonly contextKey: string;
   /** Resolve name references to full definitions */
   resolve(refs: unknown, manager?: BaseComponentManager<NamedComponent>): TDef[];

--- a/packages/agent-runtime/src/builder/index.ts
+++ b/packages/agent-runtime/src/builder/index.ts
@@ -7,6 +7,6 @@ export type { CustomBuilderConfig } from "./custom-builder";
 export { DeclarativeBuilder } from "./declarative-builder";
 export {
   WorkspaceBuilder,
-  type DomainManagers,
+  type ProjectComponentManagers,
   type WorkspaceBuildResult,
 } from "./workspace-builder";

--- a/packages/agent-runtime/src/builder/workspace-builder.test.ts
+++ b/packages/agent-runtime/src/builder/workspace-builder.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { DomainContextConfig } from "@actant/shared";
+import type { ProjectContextConfig } from "@actant/shared";
 import {
   SkillManager,
   PromptManager,
@@ -25,14 +25,14 @@ describe("WorkspaceBuilder", () => {
   describe("build() with cursor backend", () => {
     it("creates correct files for cursor backend", async () => {
       const builder = new WorkspaceBuilder();
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["skill-a", "skill-b"],
         prompts: ["system-prompt"],
         mcpServers: [{ name: "fs", command: "npx", args: ["-y", "mcp-fs"] }],
         workflow: "standard",
       };
 
-      const result = await builder.build(tmpDir, domainContext, "cursor");
+      const result = await builder.build(tmpDir, project, "cursor");
 
       expect(result.backendType).toBe("cursor");
       expect(result.verify.valid).toBe(true);
@@ -57,12 +57,12 @@ describe("WorkspaceBuilder", () => {
   describe("build() with claude-code backend", () => {
     it("creates correct files for claude-code backend", async () => {
       const builder = new WorkspaceBuilder();
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["review"],
         mcpServers: [{ name: "m1", command: "cmd", args: [] }],
       };
 
-      const result = await builder.build(tmpDir, domainContext, "claude-code");
+      const result = await builder.build(tmpDir, project, "claude-code");
 
       expect(result.backendType).toBe("claude-code");
 
@@ -81,12 +81,12 @@ describe("WorkspaceBuilder", () => {
 
     it("writes permission preset to settings when permissions provided", async () => {
       const builder = new WorkspaceBuilder();
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["review"],
         mcpServers: [{ name: "m1", command: "cmd", args: [] }],
       };
 
-      const result = await builder.build(tmpDir, domainContext, "claude-code", "standard");
+      const result = await builder.build(tmpDir, project, "claude-code", "standard");
 
       expect(result.backendType).toBe("claude-code");
 
@@ -101,11 +101,11 @@ describe("WorkspaceBuilder", () => {
   describe("build() with custom/unknown backend", () => {
     it("falls back to cursor when no builder registered", async () => {
       const builder = new WorkspaceBuilder();
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["test"],
       };
 
-      const result = await builder.build(tmpDir, domainContext, "custom");
+      const result = await builder.build(tmpDir, project, "custom");
 
       // Should use cursor fallback
       expect(result.backendType).toBe("cursor");
@@ -120,8 +120,8 @@ describe("WorkspaceBuilder", () => {
       const customBuilder = new CustomBuilder();
       builder.registerBuilder(customBuilder);
 
-      const domainContext: DomainContextConfig = { skills: ["test"] };
-      const result = await builder.build(tmpDir, domainContext, "custom");
+      const project: ProjectContextConfig = { skills: ["test"] };
+      const result = await builder.build(tmpDir, project, "custom");
 
       expect(result.backendType).toBe("custom");
       expect(result.verify.valid).toBe(true);
@@ -140,7 +140,7 @@ describe("WorkspaceBuilder", () => {
   });
 
   describe("build() with no managers", () => {
-    it("works with empty domain context", async () => {
+    it("works with an empty project context", async () => {
       const builder = new WorkspaceBuilder();
       const result = await builder.build(tmpDir, {}, "cursor");
 
@@ -151,15 +151,15 @@ describe("WorkspaceBuilder", () => {
       expect(cursorStat.isDirectory()).toBe(true);
     });
 
-    it("uses placeholders when domain context has names but no managers", async () => {
+    it("uses placeholders when project context has names but no managers", async () => {
       const builder = new WorkspaceBuilder();
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["skill-a"],
         prompts: ["prompt-a"],
         workflow: "wf-standard",
       };
 
-      const result = await builder.build(tmpDir, domainContext, "cursor");
+      const result = await builder.build(tmpDir, project, "cursor");
 
       expect(result.verify.valid).toBe(true);
 
@@ -175,7 +175,7 @@ describe("WorkspaceBuilder", () => {
     });
   });
 
-  describe("build() resolves domain context", () => {
+  describe("build() resolves project context", () => {
     it("resolves skills via SkillManager when provided", async () => {
       const skillManager = new SkillManager();
       skillManager.register({
@@ -183,12 +183,12 @@ describe("WorkspaceBuilder", () => {
         content: "Resolved content from manager",
         description: "A skill",
       });
-      const domainContext: DomainContextConfig = {
+      const project: ProjectContextConfig = {
         skills: ["resolved-skill"],
       };
 
       const wsBuilder = new WorkspaceBuilder({ skills: skillManager });
-      const result = await wsBuilder.build(tmpDir, domainContext, "cursor");
+      const result = await wsBuilder.build(tmpDir, project, "cursor");
 
       expect(result.verify.valid).toBe(true);
 

--- a/packages/agent-runtime/src/builder/workspace-builder.ts
+++ b/packages/agent-runtime/src/builder/workspace-builder.ts
@@ -1,7 +1,7 @@
 import { createLogger } from "@actant/shared";
 import type {
   AgentBackendType,
-  DomainContextConfig,
+  ProjectContextConfig,
   McpServerDefinition,
   PermissionsInput,
 } from "@actant/shared";
@@ -22,7 +22,7 @@ import {
 
 const logger = createLogger("workspace-builder");
 
-export interface DomainManagers {
+export interface ProjectComponentManagers {
   skills?: SkillManager;
   prompts?: PromptManager;
   mcp?: McpConfigManager;
@@ -39,7 +39,7 @@ export class WorkspaceBuilder {
   private readonly builders: Map<AgentBackendType, BackendBuilder>;
   private readonly handlers: ComponentTypeHandler[] = [];
 
-  constructor(private readonly managers?: DomainManagers) {
+  constructor(private readonly managers?: ProjectComponentManagers) {
     this.builders = new Map<AgentBackendType, BackendBuilder>([
       ["cursor", new CursorBuilder()],
       ["claude-code", new ClaudeCodeBuilder()],
@@ -70,7 +70,7 @@ export class WorkspaceBuilder {
 
   /**
    * Build workspace using the 6-step pipeline:
-   * 1. Resolve — select builder + resolve domain context names to definitions
+   * 1. Resolve — select builder + resolve project resource names to definitions
    * 2. Validate — check that required components exist
    * 3. Scaffold — create directory structure
    * 4. Materialize — write component files
@@ -79,7 +79,7 @@ export class WorkspaceBuilder {
    */
   async build(
     workspaceDir: string,
-    domainContext: DomainContextConfig,
+    project: ProjectContextConfig,
     backendType: AgentBackendType = "cursor",
     permissions?: PermissionsInput,
   ): Promise<WorkspaceBuildResult> {
@@ -118,7 +118,7 @@ export class WorkspaceBuilder {
     let resolvedMcpServers: McpServerDefinition[] = [];
 
     for (const handler of this.handlers) {
-      const refs = domainContext[handler.contextKey as keyof DomainContextConfig];
+      const refs = project[handler.contextKey as keyof ProjectContextConfig];
       if (refs === undefined || refs === null) continue;
       if (Array.isArray(refs) && refs.length === 0) continue;
 
@@ -132,8 +132,8 @@ export class WorkspaceBuilder {
       }
     }
 
-    if (domainContext.extensions) {
-      for (const [key, refs] of Object.entries(domainContext.extensions)) {
+    if (project.extensions) {
+      for (const [key, refs] of Object.entries(project.extensions)) {
         const handler = this.handlers.find((h) => h.contextKey === key);
         if (handler && Array.isArray(refs) && refs.length > 0) {
           const defs = handler.resolve(refs, this.getManager(key));

--- a/packages/agent-runtime/src/domain/domain-context-resolver.test.ts
+++ b/packages/agent-runtime/src/domain/domain-context-resolver.test.ts
@@ -13,7 +13,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     version: "1.0.0",
     backend: { type: "cursor" },
     provider: { type: "anthropic" },
-    domainContext: {
+    project: {
       skills: ["code-review", "ts-expert"],
       prompts: ["system-reviewer"],
       mcpServers: [{ name: "fs", command: "npx", args: ["-y", "mcp-fs"] }],
@@ -52,7 +52,7 @@ describe("Domain Context Resolution Integration", () => {
 
   it("should materialize resolved skills into AGENTS.md with full content", async () => {
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
+      projectManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
     });
     await initializer.createInstance("test-agent", "integration-tpl");
 
@@ -65,7 +65,7 @@ describe("Domain Context Resolution Integration", () => {
 
   it("should materialize resolved prompts into prompts/system.md", async () => {
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
+      projectManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
     });
     await initializer.createInstance("test-agent", "integration-tpl");
 
@@ -76,7 +76,7 @@ describe("Domain Context Resolution Integration", () => {
 
   it("should materialize resolved workflow into .trellis/workflow.md", async () => {
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
+      projectManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
     });
     await initializer.createInstance("test-agent", "integration-tpl");
 
@@ -87,7 +87,7 @@ describe("Domain Context Resolution Integration", () => {
 
   it("should materialize inline MCP configs (not name-resolved)", async () => {
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
+      projectManagers: { skills: skillMgr, prompts: promptMgr, workflows: workflowMgr },
     });
     await initializer.createInstance("test-agent", "integration-tpl");
 
@@ -98,7 +98,7 @@ describe("Domain Context Resolution Integration", () => {
   it("should throw ComponentReferenceError when skill is not registered", async () => {
     const emptySkillMgr = new SkillManager();
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: emptySkillMgr, prompts: promptMgr, workflows: workflowMgr },
+      projectManagers: { skills: emptySkillMgr, prompts: promptMgr, workflows: workflowMgr },
     });
 
     await expect(
@@ -109,7 +109,7 @@ describe("Domain Context Resolution Integration", () => {
   it("should throw ComponentReferenceError when prompt is not registered", async () => {
     const emptyPromptMgr = new PromptManager();
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: emptyPromptMgr, workflows: workflowMgr },
+      projectManagers: { skills: skillMgr, prompts: emptyPromptMgr, workflows: workflowMgr },
     });
 
     await expect(
@@ -120,7 +120,7 @@ describe("Domain Context Resolution Integration", () => {
   it("should throw ComponentReferenceError when workflow is not registered", async () => {
     const emptyWfMgr = new WorkflowManager();
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr, prompts: promptMgr, workflows: emptyWfMgr },
+      projectManagers: { skills: skillMgr, prompts: promptMgr, workflows: emptyWfMgr },
     });
 
     await expect(
@@ -139,7 +139,7 @@ describe("Domain Context Resolution Integration", () => {
 
   it("should work with partial managers (only skills resolved)", async () => {
     const initializer = new AgentInitializer(registry, tmpDir, {
-      domainManagers: { skills: skillMgr },
+      projectManagers: { skills: skillMgr },
     });
     await initializer.createInstance("partial-agent", "integration-tpl");
 

--- a/packages/agent-runtime/src/initializer/agent-initializer.test.ts
+++ b/packages/agent-runtime/src/initializer/agent-initializer.test.ts
@@ -18,7 +18,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     version: "1.0.0",
     backend: { type: "cursor" },
     provider: { type: "openai" },
-    domainContext: {
+    project: {
       skills: ["skill-a", "skill-b"],
       prompts: ["system-prompt"],
       mcpServers: [
@@ -63,7 +63,7 @@ describe("AgentInitializer", () => {
       expect(metaParsed.name).toBe("my-agent");
     });
 
-    it("should materialize domain context files", async () => {
+    it("should materialize project context files", async () => {
       await initializer.createInstance("my-agent", "test-template");
       const base = join(tmpDir, "my-agent");
 
@@ -86,7 +86,7 @@ describe("AgentInitializer", () => {
         makeTemplate({
           name: "claude-template",
           backend: { type: "claude-code", config: { executablePath: "/usr/bin/claude" } },
-          domainContext: { mcpServers: [{ name: "m1", command: "cmd", args: [] }] },
+          project: { mcpServers: [{ name: "m1", command: "cmd", args: [] }] },
         }),
       );
       const meta = await initializer.createInstance("claude-agent", "claude-template");
@@ -159,10 +159,10 @@ describe("AgentInitializer", () => {
       expect(meta.workspacePolicy).toBe("persistent");
     });
 
-    it("should create instance with minimal template (empty domainContext)", async () => {
+    it("should create instance with minimal template (empty project)", async () => {
       registry.register(makeTemplate({
         name: "minimal",
-        domainContext: {},
+        project: {},
       }));
       const meta = await initializer.createInstance("minimal-agent", "minimal");
 

--- a/packages/agent-runtime/src/initializer/agent-initializer.ts
+++ b/packages/agent-runtime/src/initializer/agent-initializer.ts
@@ -10,7 +10,7 @@ import {
   createLogger,
 } from "@actant/shared";
 import type { TemplateRegistry } from "@actant/domain-context";
-import { WorkspaceBuilder, type DomainManagers } from "../builder/workspace-builder";
+import { WorkspaceBuilder, type ProjectComponentManagers } from "../builder/workspace-builder";
 import { resolvePermissions } from "@actant/domain-context";
 import { readInstanceMeta, writeInstanceMeta } from "../state/index";
 import { InitializationPipeline } from "./pipeline/initialization-pipeline";
@@ -25,7 +25,7 @@ const logger = createLogger("agent-initializer");
 
 export interface InitializerOptions {
   defaultLaunchMode?: LaunchMode;
-  domainManagers?: DomainManagers;
+  projectManagers?: ProjectComponentManagers;
   /** Step registry for InitializerConfig pipeline execution. When provided, template.initializer.steps will be executed during createInstance(). */
   stepRegistry?: StepRegistry;
 }
@@ -55,7 +55,7 @@ export class AgentInitializer {
     private readonly instancesBaseDir: string,
     private readonly options?: InitializerOptions,
   ) {
-    this.builder = new WorkspaceBuilder(options?.domainManagers);
+    this.builder = new WorkspaceBuilder(options?.projectManagers);
     if (options?.stepRegistry) {
       this.pipeline = new InitializationPipeline(options.stepRegistry);
     }
@@ -69,7 +69,7 @@ export class AgentInitializer {
    * Create a new Agent Instance.
    * 1. Resolve template from registry
    * 2. Create workspace directory {instancesBaseDir}/{name}/
-   * 3. Materialize Domain Context files
+   * 3. Materialize project resource files
    * 4. Write .actant.json metadata
    *
    * @throws {TemplateNotFoundError} if template is not in registry
@@ -122,7 +122,7 @@ export class AgentInitializer {
       const finalPermissions = overrides?.permissions ?? template.permissions;
       await this.builder.build(
         workspaceDir,
-        template.domainContext,
+        template.project,
         template.backend.type,
         finalPermissions,
       );

--- a/packages/agent-runtime/src/initializer/index.ts
+++ b/packages/agent-runtime/src/initializer/index.ts
@@ -1,11 +1,10 @@
 /**
- * Phase B migration: AgentInitializer splits — context-building steps
- * (DomainManagers, WorkspaceBuilder) move to `@actant/context`, while
- * process-launch steps stay in `@actant/agent-runtime`.
+ * AgentInitializer assembles project resources and process-launch behavior
+ * inside `@actant/agent-runtime`.
  */
 export { AgentInitializer, type InitializerOptions, type InstanceOverrides } from "./agent-initializer";
 export { getArchetypeDefaults, type ArchetypeDefaults } from "./archetype-defaults";
-export type { DomainManagers } from "../builder/workspace-builder";
+export type { ProjectComponentManagers } from "../builder/workspace-builder";
 export {
   InitializerStepExecutor,
   StepRegistry,

--- a/packages/agent-runtime/src/initializer/pipeline/initialization-pipeline.test.ts
+++ b/packages/agent-runtime/src/initializer/pipeline/initialization-pipeline.test.ts
@@ -51,7 +51,7 @@ function makeContext(overrides?: Partial<StepContext>): StepContext {
       version: "1.0.0",
       backend: { type: "cursor" },
       provider: { type: "openai" },
-      domainContext: {},
+      project: {},
     } as AgentTemplate,
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     state: new Map(),

--- a/packages/agent-runtime/src/initializer/steps/builtin-steps.test.ts
+++ b/packages/agent-runtime/src/initializer/steps/builtin-steps.test.ts
@@ -19,7 +19,7 @@ function makeContext(workspaceDir: string): StepContext {
       version: "1.0.0",
       backend: { type: "cursor" },
       provider: { type: "openai" },
-      domainContext: {},
+      project: {},
     } as AgentTemplate,
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     state: new Map(),

--- a/packages/agent-runtime/src/manager/agent-lifecycle-scenarios.test.ts
+++ b/packages/agent-runtime/src/manager/agent-lifecycle-scenarios.test.ts
@@ -49,7 +49,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     version: "1.0.0",
     backend: { type: "test-acp" },
     provider: { type: "openai", protocol: "openai" },
-    domainContext: { skills: ["skill-a"] },
+    project: { skills: ["skill-a"] },
     archetype: "service",
     ...overrides,
   };

--- a/packages/agent-runtime/src/manager/agent-manager.endurance.test.ts
+++ b/packages/agent-runtime/src/manager/agent-manager.endurance.test.ts
@@ -35,7 +35,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     version: "1.0.0",
     backend: { type: "claude-code" },
     provider: { type: "openai", protocol: "openai" },
-    domainContext: { skills: ["skill-a"] },
+    project: { skills: ["skill-a"] },
     ...overrides,
   };
 }

--- a/packages/agent-runtime/src/manager/agent-manager.test.ts
+++ b/packages/agent-runtime/src/manager/agent-manager.test.ts
@@ -25,7 +25,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     backend: { type: "pi" },
     archetype: "service",
     provider: { type: "openai", protocol: "openai" },
-    domainContext: { skills: ["skill-a"] },
+    project: { skills: ["skill-a"] },
     ...overrides,
   };
 }

--- a/packages/agent-runtime/src/plugin/legacy-adapter.ts
+++ b/packages/agent-runtime/src/plugin/legacy-adapter.ts
@@ -1,9 +1,9 @@
-import type { DomainContextConfig, PluginDefinition } from "@actant/shared";
+import type { ProjectContextConfig, PluginDefinition } from "@actant/shared";
 import type { ActantPlugin } from "./types";
 
 /**
  * Adapts a legacy PluginDefinition (workspace-materialisation config) into
- * an ActantPlugin that only uses the domainContext plug.
+ * an ActantPlugin that only uses the project plug.
  *
  * Legacy PluginDefinitions represent external tool configurations (npm packages,
  * Cursor extensions, etc.) managed by BackendBuilder.  They have no system-level
@@ -21,7 +21,7 @@ export function adaptLegacyPlugin(def: PluginDefinition): ActantPlugin {
     name: def.name,
     scope: "actant",
 
-    domainContext(): DomainContextConfig | undefined {
+    project(): ProjectContextConfig | undefined {
       if (def.enabled === false) return undefined;
       return {
         plugins: [def.name],

--- a/packages/agent-runtime/src/plugin/plugin-host.test.ts
+++ b/packages/agent-runtime/src/plugin/plugin-host.test.ts
@@ -418,26 +418,26 @@ describe("adaptLegacyPlugin", () => {
     expect(plugin.scope).toBe("actant");
   });
 
-  it("only has domainContext plug — no runtime, hooks, contextProviders, etc.", () => {
+  it("only has project plug — no runtime, hooks, contextProviders, etc.", () => {
     const plugin = adaptLegacyPlugin(legacyDef);
     expect(plugin.runtime).toBeUndefined();
     expect(plugin.hooks).toBeUndefined();
     expect(plugin.contextProviders).toBeUndefined();
     expect(plugin.subsystems).toBeUndefined();
     expect(plugin.sources).toBeUndefined();
-    expect(plugin.domainContext).toBeDefined();
+    expect(plugin.project).toBeDefined();
   });
 
-  it("domainContext returns plugin name in plugins array when enabled", () => {
+  it("project returns plugin name in plugins array when enabled", () => {
     const plugin = adaptLegacyPlugin(legacyDef);
-    const ctx = plugin.domainContext!(baseCtx);
+    const ctx = plugin.project!(baseCtx);
     expect(ctx?.plugins).toContain("my-ext");
   });
 
-  it("domainContext returns undefined when enabled === false", () => {
+  it("project returns undefined when enabled === false", () => {
     const disabled: PluginDefinition = { ...legacyDef, enabled: false };
     const plugin = adaptLegacyPlugin(disabled);
-    expect(plugin.domainContext!(baseCtx)).toBeUndefined();
+    expect(plugin.project!(baseCtx)).toBeUndefined();
   });
 
   it("can be registered and started in PluginHost", async () => {

--- a/packages/agent-runtime/src/plugin/types.ts
+++ b/packages/agent-runtime/src/plugin/types.ts
@@ -5,7 +5,7 @@
  * HookEventBus and ContextProvider which are core-only types.
  *
  * Plug summary:
- *   1. domainContext    — inject DomainContextConfig into Agent workspace (BackendBuilder)
+ *   1. project         — inject ProjectContextConfig into Agent workspace (BackendBuilder)
  *   2. runtime         — lifecycle: init → start → tick → stop → dispose
  *   3. hooks           — register HookEventBus listeners
  *   4. contextProviders — register ContextProvider instances
@@ -14,7 +14,7 @@
  */
 
 import type {
-  DomainContextConfig,
+  ProjectContextConfig,
   SourceConfig,
   PluginContext,
   PluginScope,
@@ -40,15 +40,15 @@ export interface ActantPlugin {
    */
   readonly dependencies?: readonly string[];
 
-  // ── Plug 1: domainContext ──────────────────────────────────
+  // ── Plug 1: project ────────────────────────────────────────
   /**
-   * Returns a DomainContextConfig fragment to be merged into the agent's
+   * Returns a ProjectContextConfig fragment to be merged into the agent's
    * workspace during BackendBuilder materialisation.
    *
    * Called once per agent workspace build (not at daemon start).
    * Return undefined to inject nothing.
    */
-  domainContext?: (ctx: PluginContext) => DomainContextConfig | undefined;
+  project?: (ctx: PluginContext) => ProjectContextConfig | undefined;
 
   // ── Plug 2: runtime ───────────────────────────────────────
   /**

--- a/packages/agent-runtime/src/template/index.ts
+++ b/packages/agent-runtime/src/template/index.ts
@@ -5,7 +5,7 @@
 export {
   AgentTemplateSchema,
   ComponentOriginSchema,
-  DomainContextSchema,
+  ProjectContextSchema,
   AgentBackendSchema,
   ModelProviderSchema,
   InitializerSchema,
@@ -20,7 +20,7 @@ export {
   validateProviderConfig,
   validatePermissionsConfig,
   validateScheduleConfig,
-  validateDomainContextConfig,
+  validateProjectContextConfig,
   validateTemplate,
   TemplateLoader,
   toAgentTemplate,

--- a/packages/agent-runtime/src/testing/test-launcher.ts
+++ b/packages/agent-runtime/src/testing/test-launcher.ts
@@ -42,7 +42,7 @@ export function makeSleeperTemplate(overrides?: Partial<AgentTemplate>): AgentTe
       },
     },
     provider: { type: "openai", protocol: "openai" },
-    domainContext: {},
+    project: {},
     ...overrides,
   };
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@actant/acp": "workspace:0.5.0",
     "@actant/channel-claude": "workspace:0.5.0",
-    "@actant/context": "workspace:0.5.0",
     "@actant/agent-runtime": "workspace:0.5.0",
     "@actant/pi": "workspace:0.5.0",
     "@actant/shared": "workspace:0.5.0"

--- a/packages/api/src/daemon/__tests__/socket-server.test.ts
+++ b/packages/api/src/daemon/__tests__/socket-server.test.ts
@@ -153,7 +153,7 @@ describe("SocketServer integration", () => {
       version: "1.0.0",
       backend: { type: "claude-code" },
       provider: { type: "anthropic" },
-      domainContext: {},
+      project: {},
     }));
 
     const loadRes = await rpcCall(socketPath, {

--- a/packages/api/src/handlers/__tests__/agent-handlers.test.ts
+++ b/packages/api/src/handlers/__tests__/agent-handlers.test.ts
@@ -17,7 +17,7 @@ describe("agent handlers", () => {
     version: "1.0.0",
     backend: { type: "claude-code" },
     provider: { type: "anthropic" },
-    domainContext: {},
+    project: {},
   };
 
   beforeAll(async () => {

--- a/packages/api/src/handlers/__tests__/template-handlers.test.ts
+++ b/packages/api/src/handlers/__tests__/template-handlers.test.ts
@@ -17,7 +17,7 @@ describe("template handlers", () => {
     version: "1.0.0",
     backend: { type: "cursor" },
     provider: { type: "anthropic" },
-    domainContext: {},
+    project: {},
   };
 
   beforeAll(async () => {

--- a/packages/api/src/services/__tests__/bootstrap-profile.test.ts
+++ b/packages/api/src/services/__tests__/bootstrap-profile.test.ts
@@ -21,7 +21,7 @@ describe("AppContext bootstrap profile", () => {
         version: "1.0.0",
         backend: { type: "claude-code" },
         provider: { type: "anthropic" },
-        domainContext: {},
+        project: {},
       }),
       "utf-8",
     );

--- a/packages/api/src/services/__tests__/domain-context-integration.test.ts
+++ b/packages/api/src/services/__tests__/domain-context-integration.test.ts
@@ -41,7 +41,7 @@ describe("Domain Context Full Pipeline", () => {
     version: "1.0.0",
     backend: { type: "cursor" },
     provider: { type: "anthropic" },
-    domainContext: {
+    project: {
       skills: ["test-skill"],
       prompts: ["test-prompt"],
       mcpServers: [{ name: "inline-mcp", command: "node", args: ["server.js"] }],
@@ -142,7 +142,7 @@ describe("Domain Context Full Pipeline", () => {
       version: "1.0.0",
       backend: { type: "claude-code" },
       provider: { type: "anthropic" },
-      domainContext: {
+      project: {
         skills: ["test-skill"],
         mcpServers: [{ name: "fs", command: "npx", args: ["mcp-fs"] }],
       },

--- a/packages/api/src/services/__tests__/hub-context.test.ts
+++ b/packages/api/src/services/__tests__/hub-context.test.ts
@@ -23,7 +23,7 @@ describe("HubContextService", () => {
         version: "1.0.0",
         backend: { type: "claude-code" },
         provider: { type: "anthropic" },
-        domainContext: {},
+        project: {},
       }),
       "utf-8",
     );

--- a/packages/api/src/services/__tests__/mvp-e2e-integration.test.ts
+++ b/packages/api/src/services/__tests__/mvp-e2e-integration.test.ts
@@ -45,7 +45,7 @@ describe("MVP E2E Integration", () => {
     description: "A test code review agent",
     backend: { type: "claude-code", config: { model: "claude-sonnet-4-20250514" } },
     provider: { type: "anthropic" },
-    domainContext: {
+    project: {
       skills: ["test-review"],
       prompts: ["test-system-prompt"],
       mcpServers: [{ name: "fs", command: "npx", args: ["-y", "mcp-fs"] }],

--- a/packages/api/src/services/app-context.ts
+++ b/packages/api/src/services/app-context.ts
@@ -41,18 +41,24 @@ import {
   canvasSourceFactory,
   vcsSourceFactory,
   processSourceFactory,
+  createDomainSource,
+  createAgentRegistrySource,
   RoutingChannelManager,
+  type ActantChannel,
+  type ActantChannelManager,
   type ActionContext,
+  type ChannelCapabilities,
+  type ChannelConnectOptions,
+  type ChannelHostServices,
   type LauncherMode,
 } from "@actant/agent-runtime";
 import { CanvasStore } from "./canvas-store";
-import { ContextManager, DomainContextSource, AgentStatusSource, type AgentStatusProvider, type AgentStatusInfo } from "@actant/context";
 import type { HostCapability, HostProfile, HostRuntimeState, ModelApiProtocol } from "@actant/shared";
 import { AcpConnectionManager, AcpChannelManagerAdapter } from "@actant/acp";
-import { ClaudeChannelManagerAdapter } from "@actant/channel-claude";
 import { PiBuilder, PiCommunicator, configFromBackend, ACP_BRIDGE_PATH } from "@actant/pi";
 import { createLogger, getIpcPath, initLogDir, normalizeIpcPath } from "@actant/shared";
 import { HubContextService } from "./hub-context";
+import { RuntimeToolRegistry } from "./runtime-tool-registry";
 
 const logger = createLogger("app-context");
 
@@ -73,6 +79,74 @@ interface UserConfig {
     apiKey?: string;
   }>;
   [key: string]: unknown;
+}
+
+class LazyClaudeChannelManagerAdapter implements ActantChannelManager {
+  private manager?: ActantChannelManager;
+  private managerPromise?: Promise<ActantChannelManager>;
+
+  async connect(
+    name: string,
+    options: ChannelConnectOptions,
+    hostServices: ChannelHostServices,
+  ): Promise<{ sessionId: string; capabilities: ChannelCapabilities }> {
+    const manager = await this.getManager();
+    return manager.connect(name, options, hostServices);
+  }
+
+  has(name: string): boolean {
+    return this.manager?.has(name) ?? false;
+  }
+
+  getChannel(name: string): ActantChannel | undefined {
+    return this.manager?.getChannel(name);
+  }
+
+  getPrimarySessionId(name: string): string | undefined {
+    return this.manager?.getPrimarySessionId(name);
+  }
+
+  getCapabilities(name: string): ChannelCapabilities | undefined {
+    const manager = this.manager;
+    if (!manager) return undefined;
+    return manager.getCapabilities?.(name) ?? manager.getChannel(name)?.capabilities;
+  }
+
+  setCurrentActivitySession(name: string, id: string | null): void {
+    this.manager?.setCurrentActivitySession?.(name, id);
+  }
+
+  async disconnect(name: string): Promise<void> {
+    await this.manager?.disconnect(name);
+  }
+
+  async disposeAll(): Promise<void> {
+    await this.manager?.disposeAll();
+  }
+
+  private async getManager(): Promise<ActantChannelManager> {
+    if (this.manager) {
+      return this.manager;
+    }
+
+    if (!this.managerPromise) {
+      this.managerPromise = import("@actant/channel-claude")
+        .then(({ ClaudeChannelManagerAdapter }) => {
+          const manager = new ClaudeChannelManagerAdapter();
+          this.manager = manager;
+          return manager;
+        })
+        .catch((error: unknown) => {
+          this.managerPromise = undefined;
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Claude backend is unavailable because @actant/channel-claude or its SDK dependencies could not be loaded: ${detail}`,
+          );
+        });
+    }
+
+    return this.managerPromise;
+  }
 }
 
 export interface AppConfig {
@@ -106,7 +180,7 @@ export class AppContext {
   readonly pluginManager: PluginManager;
   readonly agentInitializer: AgentInitializer;
   readonly acpConnectionManager: AcpConnectionManager;
-  readonly claudeChannelManager: ClaudeChannelManagerAdapter;
+  readonly claudeChannelManager: ActantChannelManager;
   readonly agentManager: AgentManager;
   readonly sessionRegistry: SessionRegistry;
   readonly sourceManager: SourceManager;
@@ -124,7 +198,7 @@ export class AppContext {
   readonly sourceFactoryRegistry: SourceFactoryRegistry;
   readonly hostProfile: HostProfile;
   readonly hubContext: HubContextService;
-  readonly contextManager: ContextManager;
+  readonly toolRegistry: RuntimeToolRegistry;
   private vfsLifecycleManager?: VfsLifecycleManager;
 
   private initialized = false;
@@ -177,7 +251,7 @@ export class AppContext {
       this.templateRegistry,
       this.instancesDir,
       {
-        domainManagers: {
+        projectManagers: {
           skills: this.skillManager,
           prompts: this.promptManager,
           mcp: this.mcpConfigManager,
@@ -188,7 +262,7 @@ export class AppContext {
       },
     );
     this.acpConnectionManager = new AcpConnectionManager();
-    this.claudeChannelManager = new ClaudeChannelManagerAdapter();
+    this.claudeChannelManager = new LazyClaudeChannelManagerAdapter();
     this.sessionRegistry = new SessionRegistry();
     this.recordSystem = new RecordSystem({
       globalDir: join(this.homeDir, "records", "global"),
@@ -230,7 +304,7 @@ export class AppContext {
     this.sourceFactoryRegistry.register(vcsSourceFactory);
     this.sourceFactoryRegistry.register(processSourceFactory);
     this.hubContext = new HubContextService(this);
-    this.contextManager = new ContextManager();
+    this.toolRegistry = new RuntimeToolRegistry();
   }
 
   async init(): Promise<void> {
@@ -598,7 +672,7 @@ export class AppContext {
       if (!agentName) return;
       this.hookRegistry.unregisterAgent(agentName);
       this.canvasStore.remove(agentName);
-      this.contextManager.unregisterTool(`actant_${agentName}`);
+      this.toolRegistry.unregister(`actant_${agentName}`);
     });
 
     this.eventBus.on("process:start", (payload) => {
@@ -607,7 +681,7 @@ export class AppContext {
       const meta = this.agentManager.listAgents().find((a) => a.name === name);
       if (!meta?.toolSchema) return;
       try {
-        this.contextManager.registerTool({
+        this.toolRegistry.register({
           name: `actant_${name}`,
           description: (meta.metadata?.["description"] as string | undefined) ?? `Internal Agent: ${name}`,
           inputSchema: meta.toolSchema,
@@ -615,7 +689,7 @@ export class AppContext {
             return this.agentManager.promptAgent(name, (params["message"] as string) ?? JSON.stringify(params));
           },
         });
-        logger.info({ agent: name }, "Agent registered as ContextManager tool");
+        logger.info({ agent: name }, "Agent registered in runtime tool registry");
       } catch (err) {
         logger.warn({ agent: name, error: err }, "Failed to register agent as tool");
       }
@@ -623,7 +697,7 @@ export class AppContext {
 
     const unregisterAgentTool = (payload: { agentName?: string }) => {
       if (payload.agentName) {
-        this.contextManager.unregisterTool(`actant_${payload.agentName}`);
+        this.toolRegistry.unregister(`actant_${payload.agentName}`);
       }
     };
     this.eventBus.on("process:stop", unregisterAgentTool);
@@ -692,31 +766,31 @@ export class AppContext {
       }
     });
 
-    this.contextManager.registerSource(new DomainContextSource({
-      skillManager: this.skillManager,
-      promptManager: this.promptManager,
-      mcpConfigManager: this.mcpConfigManager,
-      workflowManager: this.workflowManager,
-      templateRegistry: this.templateRegistry,
-    }));
-
-    const agentStatusProvider: AgentStatusProvider = {
-      listAgents: (): AgentStatusInfo[] =>
-        this.agentManager.listAgents().map(agentMetaToStatusInfo),
-      getAgent: (name: string): AgentStatusInfo | undefined => {
-        const meta = this.agentManager.listAgents().find((a) => a.name === name);
-        return meta ? agentMetaToStatusInfo(meta) : undefined;
-      },
-    };
-    this.contextManager.registerSource(new AgentStatusSource(agentStatusProvider));
-    this.contextManager.mountSources(reg);
+    this.mountCoreResourceSources(reg);
 
     logger.info({ mounts: reg.size }, "VFS initialized with default mounts");
   }
 
-  /** Refresh ContextManager VFS mounts (call after sources change). */
+  /** Refresh the default resource mounts after domain content changes. */
   refreshContextMounts(): void {
-    this.contextManager.mountSources(this.vfsRegistry);
+    this.mountCoreResourceSources(this.vfsRegistry);
+  }
+
+  private mountCoreResourceSources(registry: VfsRegistry): void {
+    const lifecycle = { type: "daemon" } as const;
+    const coreSources = [
+      createDomainSource(this.skillManager, "skills", "/skills", lifecycle),
+      createDomainSource(this.promptManager, "prompts", "/prompts", lifecycle),
+      createDomainSource(this.mcpConfigManager, "mcp", "/mcp", lifecycle),
+      createDomainSource(this.workflowManager, "workflows", "/workflows", lifecycle),
+      createDomainSource(this.templateRegistry, "templates", "/templates", lifecycle),
+      createAgentRegistrySource(this.agentManager, "/agents", lifecycle),
+    ];
+
+    for (const source of coreSources) {
+      registry.unmount(source.name);
+      registry.mount(source);
+    }
   }
 
   private async loadDomainComponents(): Promise<void> {
@@ -741,22 +815,4 @@ export class AppContext {
       }
     }
   }
-}
-
-function agentMetaToStatusInfo(meta: {
-  name: string;
-  metadata?: Record<string, string>;
-  archetype?: string;
-  status: string;
-  startedAt?: string;
-  toolSchema?: Record<string, unknown>;
-}): AgentStatusInfo {
-  return {
-    name: meta.name,
-    description: meta.metadata?.["description"],
-    archetype: meta.archetype ?? "repo",
-    status: meta.status,
-    startedAt: meta.startedAt,
-    toolSchema: meta.toolSchema,
-  };
 }

--- a/packages/api/src/services/hub-context.ts
+++ b/packages/api/src/services/hub-context.ts
@@ -5,7 +5,6 @@ import type {
   HubStatusResult,
   VfsSourceRegistration,
 } from "@actant/shared";
-import { DomainContextSource } from "@actant/context";
 import {
   createProjectContextFactoryRegistry,
   createProjectContextRegistrations,
@@ -35,8 +34,6 @@ export interface ActiveHubContext {
   mounts: HubActivateResult["mounts"];
   sourceNames: string[];
 }
-
-const HUB_DOMAIN_SOURCE_NAME = "hub-domain";
 
 export class HubContextService {
   private readonly factoryRegistry = createProjectContextFactoryRegistry();
@@ -104,18 +101,6 @@ export class HubContextService {
     const context = await loadProjectContext(projectDir);
     const registrations = buildHubRegistrations(context, this.factoryRegistry);
     await this.replaceActiveContext(registrations);
-
-    this.appContext.contextManager.unregisterSource(HUB_DOMAIN_SOURCE_NAME);
-    this.appContext.contextManager.registerSource(new DomainContextSource(
-      {
-        skillManager: context.managers.skillManager,
-        promptManager: context.managers.promptManager,
-        mcpConfigManager: context.managers.mcpConfigManager,
-        workflowManager: context.managers.workflowManager,
-        templateRegistry: context.managers.templateRegistry,
-      },
-      { name: HUB_DOMAIN_SOURCE_NAME },
-    ));
 
     const next: ActiveHubContext = {
       projectRoot: context.projectRoot,

--- a/packages/api/src/services/project-context.ts
+++ b/packages/api/src/services/project-context.ts
@@ -342,16 +342,16 @@ function injectSourceComponents(
     managers.workflowManager.register(ns(workflow));
   }
   for (const template of result.templates) {
-    const dc = template.domainContext;
+    const project = template.project;
     managers.templateRegistry.register({
       ...template,
       name: `${packageName}@${template.name}`,
-      domainContext: {
-        ...dc,
-        skills: dc.skills?.map(nsRef),
-        prompts: dc.prompts?.map(nsRef),
-        subAgents: dc.subAgents?.map(nsRef),
-        workflow: dc.workflow ? nsRef(dc.workflow) : dc.workflow,
+      project: {
+        ...project,
+        skills: project.skills?.map(nsRef),
+        prompts: project.prompts?.map(nsRef),
+        subAgents: project.subAgents?.map(nsRef),
+        workflow: project.workflow ? nsRef(project.workflow) : project.workflow,
       },
     } as AgentTemplate);
   }

--- a/packages/api/src/services/runtime-tool-registry.ts
+++ b/packages/api/src/services/runtime-tool-registry.ts
@@ -1,0 +1,29 @@
+export interface RuntimeToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+export class RuntimeToolRegistry {
+  private readonly tools = new Map<string, RuntimeToolDefinition>();
+
+  register(tool: RuntimeToolDefinition): void {
+    if (this.tools.has(tool.name)) {
+      throw new Error(`Tool "${tool.name}" is already registered`);
+    }
+    this.tools.set(tool.name, tool);
+  }
+
+  unregister(name: string): boolean {
+    return this.tools.delete(name);
+  }
+
+  get(name: string): RuntimeToolDefinition | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): RuntimeToolDefinition[] {
+    return Array.from(this.tools.values());
+  }
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "./src"
   },
   "include": ["src"],
-  "references": [{ "path": "../shared" }, { "path": "../context" }, { "path": "../agent-runtime" }, { "path": "../acp" }, { "path": "../pi" }]
+  "references": [{ "path": "../shared" }, { "path": "../context" }, { "path": "../agent-runtime" }, { "path": "../acp" }, { "path": "../pi" }, { "path": "../channel-claude" }]
 }

--- a/packages/cli/src/__tests__/e2e-cli.test.ts
+++ b/packages/cli/src/__tests__/e2e-cli.test.ts
@@ -79,7 +79,7 @@ describe("CLI E2E (stdio)", { timeout: 20_000 }, () => {
     version: "1.0.0",
     backend: { type: "claude-code" },
     provider: { type: "anthropic" },
-    domainContext: {},
+    project: {},
   };
 
   beforeAll(async () => {

--- a/packages/cli/src/commands/__tests__/commands.test.ts
+++ b/packages/cli/src/commands/__tests__/commands.test.ts
@@ -50,7 +50,7 @@ const minimalTemplate = {
   version: "1.0.0",
   backend: { type: "cursor" as const },
   provider: { type: "anthropic" as const },
-  domainContext: {},
+  project: {},
 };
 
 describe("createAgentCreateCommand", () => {

--- a/packages/cli/src/output/__tests__/formatter.test.ts
+++ b/packages/cli/src/output/__tests__/formatter.test.ts
@@ -17,7 +17,7 @@ const minimalTemplate: AgentTemplate = {
   version: "1.0.0",
   backend: { type: "cursor" },
   provider: { type: "anthropic" },
-  domainContext: {},
+  project: {},
 };
 
 const fullTemplate: AgentTemplate = {
@@ -26,7 +26,7 @@ const fullTemplate: AgentTemplate = {
   description: "A full template",
   backend: { type: "cursor", config: { executablePath: "/bin/cursor" } },
   provider: { type: "anthropic", config: { model: "claude-3" } },
-  domainContext: {
+  project: {
     skills: ["skill-a", "skill-b"],
     prompts: ["prompt-1"],
     mcpServers: [
@@ -106,7 +106,7 @@ describe("formatTemplateDetail", () => {
     const parsed = JSON.parse(out) as AgentTemplate;
     expect(parsed.name).toBe("full-tpl");
     expect(parsed.version).toBe("2.0.0");
-    expect(parsed.domainContext.skills).toEqual(["skill-a", "skill-b"]);
+    expect(parsed.project.skills).toEqual(["skill-a", "skill-b"]);
   });
 
   it("quiet format", () => {
@@ -125,7 +125,7 @@ describe("formatTemplateDetail", () => {
     expect(plain).toContain("cursor");
     expect(plain).toContain("Provider:");
     expect(plain).toContain("anthropic");
-    expect(plain).toContain("Domain Context:");
+    expect(plain).toContain("Project Context:");
     expect(plain).toContain("skill-a");
     expect(plain).toContain("skill-b");
     expect(plain).toContain("prompt-1");

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -55,7 +55,7 @@ export function formatTemplateDetail(
     return template.name;
   }
 
-  const ctx = template.domainContext;
+  const ctx = template.project;
   const lines = [
     `${chalk.bold("Template:")} ${template.name}`,
     `${chalk.bold("Version:")}  ${template.version}`,
@@ -68,7 +68,7 @@ export function formatTemplateDetail(
   }
 
   lines.push("");
-  lines.push(chalk.bold("Domain Context:"));
+  lines.push(chalk.bold("Project Context:"));
   lines.push(`  Skills:      ${ctx.skills?.length ?? 0} ref(s)   ${(ctx.skills ?? []).join(", ") || chalk.dim("none")}`);
   lines.push(`  Prompts:     ${ctx.prompts?.length ?? 0} ref(s)   ${(ctx.prompts ?? []).join(", ") || chalk.dim("none")}`);
   lines.push(`  MCP Servers: ${ctx.mcpServers?.length ?? 0} ref(s)   ${(ctx.mcpServers ?? []).map((s) => s.name).join(", ") || chalk.dim("none")}`);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,5 +6,12 @@
     "rootDir": "./src"
   },
   "include": ["src", "bin"],
-  "references": [{ "path": "../shared" }, { "path": "../agent-runtime" }, { "path": "../acp" }, { "path": "../api" }, { "path": "../tui" }]
+  "references": [
+    { "path": "../shared" },
+    { "path": "../agent-runtime" },
+    { "path": "../acp" },
+    { "path": "../api" },
+    { "path": "../rest-api" },
+    { "path": "../tui" }
+  ]
 }

--- a/packages/dashboard/client/src/components/orchestration/template-card.tsx
+++ b/packages/dashboard/client/src/components/orchestration/template-card.tsx
@@ -15,7 +15,7 @@ export function TemplateCard({ template }: TemplateCardProps) {
   const archetype = resolveArchetype(template.archetype);
   const config = ARCHETYPE_CONFIG[archetype];
   const Icon = config.icon;
-  const skillCount = template.domainContext?.skills?.length ?? 0;
+  const skillCount = template.project?.skills?.length ?? 0;
   const layer = template.metadata?.layer;
 
   return (

--- a/packages/dashboard/client/src/components/orchestration/template-preview.tsx
+++ b/packages/dashboard/client/src/components/orchestration/template-preview.tsx
@@ -99,7 +99,7 @@ export function buildTemplateJson(
     description: basic.description,
     archetype: arch,
     backend: { type: basic.backend },
-    domainContext: {
+    project: {
       skills,
       prompts: basic.prompt ? [`${basic.name}-system-prompt`] : [],
       mcpServers: [],

--- a/packages/dashboard/client/src/lib/api.ts
+++ b/packages/dashboard/client/src/lib/api.ts
@@ -39,7 +39,7 @@ export interface TemplateListItem {
   description?: string;
   archetype?: string;
   metadata?: Record<string, string>;
-  domainContext?: { skills?: string[]; prompts?: string[]; mcpServers?: string[] };
+  project?: { skills?: string[]; prompts?: string[]; mcpServers?: string[] };
   schedule?: Record<string, unknown>;
 }
 

--- a/packages/dashboard/client/src/pages/orchestration/index.tsx
+++ b/packages/dashboard/client/src/pages/orchestration/index.tsx
@@ -171,7 +171,7 @@ function TemplateTable({ templates }: { templates: TemplateListItem[] }) {
                 <TableCell className="capitalize">
                   {tpl.metadata?.layer ?? "—"}
                 </TableCell>
-                <TableCell>{tpl.domainContext?.skills?.length ?? 0}</TableCell>
+                <TableCell>{tpl.project?.skills?.length ?? 0}</TableCell>
                 <TableCell>{tpl.version ?? "—"}</TableCell>
               </TableRow>
             );

--- a/packages/dashboard/client/src/pages/orchestration/instance-create.tsx
+++ b/packages/dashboard/client/src/pages/orchestration/instance-create.tsx
@@ -72,7 +72,7 @@ export function InstanceCreatePage() {
   const initFromTemplate = (tpl: TemplateListItem) => {
     const arch = resolveArchetype(tpl.archetype);
     setSelectedArchetype(arch);
-    setCustomSkills(tpl.domainContext?.skills ?? []);
+    setCustomSkills(tpl.project?.skills ?? []);
     setInstanceName(`${tpl.name}-a1`);
     if (tpl.schedule) {
       const sched = tpl.schedule as Record<string, unknown>;
@@ -140,7 +140,7 @@ export function InstanceCreatePage() {
       };
       if (customize) {
         body.overrides = {
-          domainContext: { skills: customSkills },
+          project: { skills: customSkills },
           ...(isEmployee ? { schedule: buildScheduleOverride(customScheduler) } : {}),
         };
       }
@@ -267,7 +267,7 @@ export function InstanceCreatePage() {
                             {t(`archetype.${arch}`)}
                           </Badge>
                           <Badge variant="secondary" className="text-xs">
-                            {t("orchestration.skillCount", { count: tpl.domainContext?.skills?.length ?? 0 })}
+                            {t("orchestration.skillCount", { count: tpl.project?.skills?.length ?? 0 })}
                           </Badge>
                         </div>
                       </CardContent>
@@ -366,7 +366,7 @@ export function InstanceCreatePage() {
               <ConfirmField
                 label={t("orchestration.previewSkillCount")}
                 value={t("orchestration.skillCount", {
-                  count: customize ? customSkills.length : (selectedTemplate?.domainContext?.skills?.length ?? 0),
+                  count: customize ? customSkills.length : (selectedTemplate?.project?.skills?.length ?? 0),
                 })}
               />
               <ConfirmField
@@ -385,7 +385,7 @@ export function InstanceCreatePage() {
                     <pre className="text-xs font-mono whitespace-pre-wrap">
                       {JSON.stringify(
                         {
-                          domainContext: { skills: customSkills },
+                          project: { skills: customSkills },
                           ...(isEmployee ? { schedule: buildScheduleOverride(customScheduler) } : {}),
                         },
                         null,

--- a/packages/dashboard/client/src/pages/orchestration/template-detail.tsx
+++ b/packages/dashboard/client/src/pages/orchestration/template-detail.tsx
@@ -72,8 +72,8 @@ export function TemplateDetailPage() {
   const archetype = resolveArchetype(template.archetype);
   const config = ARCHETYPE_CONFIG[archetype];
   const Icon = config.icon;
-  const skills = template.domainContext?.skills ?? [];
-  const prompts = template.domainContext?.prompts ?? [];
+  const skills = template.project?.skills ?? [];
+  const prompts = template.project?.prompts ?? [];
   const layer = template.metadata?.layer;
   const schedule = template.schedule as Record<string, unknown> | undefined;
   const hasSchedule = schedule && Object.keys(schedule).length > 0;

--- a/packages/domain-context/src/index.ts
+++ b/packages/domain-context/src/index.ts
@@ -13,7 +13,7 @@ export { PluginManager } from "./domain/plugin/plugin-manager";
 export {
   AgentTemplateSchema,
   ComponentOriginSchema,
-  DomainContextSchema,
+  ProjectContextSchema,
   AgentBackendSchema,
   ModelProviderSchema,
   InitializerSchema,
@@ -30,7 +30,7 @@ export {
   validateProviderConfig,
   validatePermissionsConfig,
   validateScheduleConfig,
-  validateDomainContextConfig,
+  validateProjectContextConfig,
   validateTemplate,
   type StepRegistryLike,
 } from "./template/schema/config-validators";

--- a/packages/domain-context/src/template/loader/__fixtures__/complex-template.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/complex-template.json
@@ -16,7 +16,7 @@
       "maxTokens": 8192
     }
   },
-  "domainContext": {
+  "project": {
     "skills": ["unreal-engine", "cpp-expert", "blueprint-specialist"],
     "prompts": ["system-game-dev", "code-style-ue5"],
     "mcpServers": [

--- a/packages/domain-context/src/template/loader/__fixtures__/full-featured-template.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/full-featured-template.json
@@ -9,7 +9,7 @@
   "provider": {
     "type": "anthropic"
   },
-  "domainContext": {
+  "project": {
     "skills": ["web-search"],
     "prompts": ["system-searcher"],
     "mcpServers": [],

--- a/packages/domain-context/src/template/loader/__fixtures__/invalid-bad-version.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/invalid-bad-version.json
@@ -7,5 +7,5 @@
   "provider": {
     "type": "openai"
   },
-  "domainContext": {}
+  "project": {}
 }

--- a/packages/domain-context/src/template/loader/__fixtures__/invalid-missing-name.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/invalid-missing-name.json
@@ -6,5 +6,5 @@
   "provider": {
     "type": "openai"
   },
-  "domainContext": {}
+  "project": {}
 }

--- a/packages/domain-context/src/template/loader/__fixtures__/minimal-template.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/minimal-template.json
@@ -7,5 +7,5 @@
   "provider": {
     "type": "openai"
   },
-  "domainContext": {}
+  "project": {}
 }

--- a/packages/domain-context/src/template/loader/__fixtures__/valid-template.json
+++ b/packages/domain-context/src/template/loader/__fixtures__/valid-template.json
@@ -14,7 +14,7 @@
       "apiKeyEnv": "ANTHROPIC_API_KEY"
     }
   },
-  "domainContext": {
+  "project": {
     "skills": ["code-review", "typescript-expert"],
     "prompts": ["system-code-reviewer"],
     "mcpServers": [

--- a/packages/domain-context/src/template/loader/template-loader.test.ts
+++ b/packages/domain-context/src/template/loader/template-loader.test.ts
@@ -24,9 +24,9 @@ describe("TemplateLoader", () => {
       expect(template.description).toBe("A code review agent powered by Claude");
       expect(template.backend.type).toBe("claude-code");
       expect(template.provider?.type).toBe("anthropic");
-      expect(template.domainContext.skills).toEqual(["code-review", "typescript-expert"]);
-      expect(template.domainContext.mcpServers).toHaveLength(1);
-      expect(template.domainContext.mcpServers?.[0]?.name).toBe("filesystem");
+      expect(template.project.skills).toEqual(["code-review", "typescript-expert"]);
+      expect(template.project.mcpServers).toHaveLength(1);
+      expect(template.project.mcpServers?.[0]?.name).toBe("filesystem");
       expect(template.initializer?.steps).toHaveLength(3);
       expect(template.metadata).toEqual({
         author: "Actant Team",
@@ -42,11 +42,11 @@ describe("TemplateLoader", () => {
       expect(template.description).toBeUndefined();
       expect(template.backend.type).toBe("cursor");
       expect(template.provider?.type).toBe("openai");
-      expect(template.domainContext.skills).toEqual([]);
-      expect(template.domainContext.prompts).toEqual([]);
-      expect(template.domainContext.mcpServers).toEqual([]);
-      expect(template.domainContext.workflow).toBeUndefined();
-      expect(template.domainContext.subAgents).toEqual([]);
+      expect(template.project.skills).toEqual([]);
+      expect(template.project.prompts).toEqual([]);
+      expect(template.project.mcpServers).toEqual([]);
+      expect(template.project.workflow).toBeUndefined();
+      expect(template.project.subAgents).toEqual([]);
       expect(template.initializer).toBeUndefined();
       expect(template.metadata).toBeUndefined();
     });
@@ -56,11 +56,11 @@ describe("TemplateLoader", () => {
 
       expect(template.name).toBe("game-dev-assistant");
       expect(template.version).toBe("2.3.1");
-      expect(template.domainContext.skills).toHaveLength(3);
-      expect(template.domainContext.mcpServers).toHaveLength(2);
-      expect(template.domainContext.subAgents).toEqual(["code-reviewer", "test-runner"]);
+      expect(template.project.skills).toHaveLength(3);
+      expect(template.project.mcpServers).toHaveLength(2);
+      expect(template.project.subAgents).toEqual(["code-reviewer", "test-runner"]);
       expect(template.initializer?.steps).toHaveLength(4);
-      expect(template.domainContext.mcpServers?.[1]?.env).toEqual({
+      expect(template.project.mcpServers?.[1]?.env).toEqual({
         DB_URL: "postgres://localhost:5432/gamedb",
       });
     });
@@ -91,10 +91,10 @@ describe("TemplateLoader", () => {
       expect(perms.sandbox?.enabled).toBe(true);
 
       // plugins
-      expect(template.domainContext.plugins).toEqual(["rate-limiter", "cache"]);
+      expect(template.project.plugins).toEqual(["rate-limiter", "cache"]);
 
       // extensions
-      expect(template.domainContext.extensions).toEqual({
+      expect(template.project.extensions).toEqual({
         customSources: ["rss-feed", "api-endpoint"],
       });
     });
@@ -102,8 +102,8 @@ describe("TemplateLoader", () => {
     it("should default plugins to empty array and omit extensions when absent", async () => {
       const template = await loader.loadFromFile(join(FIXTURES, "minimal-template.json"));
 
-      expect(template.domainContext.plugins).toEqual([]);
-      expect(template.domainContext.extensions).toBeUndefined();
+      expect(template.project.plugins).toEqual([]);
+      expect(template.project.extensions).toBeUndefined();
       expect(template.permissions).toBeUndefined();
       expect(template.schedule).toBeUndefined();
     });
@@ -114,7 +114,7 @@ describe("TemplateLoader", () => {
         version: "1.0.0",
         backend: { type: "cursor" },
         provider: { type: "openai" },
-        domainContext: {},
+        project: {},
         rules: ["Always respond in English", "Be concise"],
         toolSchema: { my_tool: { type: "object", properties: { q: { type: "string" } } } },
       });
@@ -136,7 +136,7 @@ describe("TemplateLoader", () => {
         version: "1.0.0",
         backend: { type: "cursor" },
         provider: { type: "openai" },
-        domainContext: {},
+        project: {},
         permissions: "permissive",
       });
       const template = await loader.loadFromString(json);
@@ -177,7 +177,7 @@ describe("TemplateLoader", () => {
         version: "1.0.0",
         backend: { type: "cursor" },
         provider: { type: "openai" },
-        domainContext: {},
+        project: {},
       });
       const template = await loader.loadFromString(json);
 

--- a/packages/domain-context/src/template/loader/template-loader.ts
+++ b/packages/domain-context/src/template/loader/template-loader.ts
@@ -111,19 +111,19 @@ export function toAgentTemplate(output: AgentTemplateOutput): AgentTemplate {
     tags: output.tags,
     backend: output.backend,
     provider: output.provider,
-    domainContext: {
-      skills: output.domainContext.skills,
-      prompts: output.domainContext.prompts,
-      mcpServers: output.domainContext.mcpServers.map((s) => ({
+    project: {
+      skills: output.project.skills,
+      prompts: output.project.prompts,
+      mcpServers: output.project.mcpServers.map((s) => ({
         name: s.name,
         command: s.command,
         args: s.args,
         env: s.env,
       })),
-      workflow: output.domainContext.workflow,
-      subAgents: output.domainContext.subAgents,
-      plugins: output.domainContext.plugins,
-      extensions: output.domainContext.extensions,
+      workflow: output.project.workflow,
+      subAgents: output.project.subAgents,
+      plugins: output.project.plugins,
+      extensions: output.project.extensions,
     },
     initializer: output.initializer,
     permissions: output.permissions,

--- a/packages/domain-context/src/template/registry/template-registry.test.ts
+++ b/packages/domain-context/src/template/registry/template-registry.test.ts
@@ -12,7 +12,7 @@ function makeTemplate(overrides?: Partial<AgentTemplate>): AgentTemplate {
     version: "1.0.0",
     backend: { type: "cursor" },
     provider: { type: "openai" },
-    domainContext: {},
+    project: {},
     ...overrides,
   };
 }

--- a/packages/domain-context/src/template/schema/config-validators.ts
+++ b/packages/domain-context/src/template/schema/config-validators.ts
@@ -9,14 +9,14 @@ import type {
   AgentBackendConfig,
   ModelProviderConfig,
   PermissionsInput,
-  DomainContextConfig,
+  ProjectContextConfig,
   AgentTemplate,
 } from "@actant/shared";
 import {
   AgentBackendSchema,
   ModelProviderSchema,
   PermissionsInputSchema,
-  DomainContextSchema,
+  ProjectContextSchema,
   AgentTemplateSchema,
 } from "./template-schema";
 import { ScheduleConfigSchema, type ScheduleConfig } from "../../schemas/schedule-config";
@@ -113,8 +113,8 @@ export function validateScheduleConfig(data: unknown): ConfigValidationResult<Sc
   return { valid: true, data: result.data, errors: [], warnings };
 }
 
-export function validateDomainContextConfig(data: unknown): ConfigValidationResult<DomainContextConfig> {
-  const result = DomainContextSchema.safeParse(data);
+export function validateProjectContextConfig(data: unknown): ConfigValidationResult<ProjectContextConfig> {
+  const result = ProjectContextSchema.safeParse(data);
   if (!result.success) {
     return { valid: false, errors: zodToIssues(result.error), warnings: [] };
   }
@@ -123,13 +123,13 @@ export function validateDomainContextConfig(data: unknown): ConfigValidationResu
   const ctx = result.data;
   if (ctx.subAgents && ctx.subAgents.length > 0 && (!ctx.skills || ctx.skills.length === 0) && (!ctx.prompts || ctx.prompts.length === 0)) {
     warnings.push(warning(
-      "domainContext",
-      "subAgents are defined but no skills or prompts; the agent may lack domain context",
-      "EMPTY_DOMAIN_WITH_SUBAGENTS",
+      "project",
+      "subAgents are defined but no skills or prompts; the agent may lack project context",
+      "EMPTY_PROJECT_WITH_SUBAGENTS",
     ));
   }
 
-  return { valid: true, data: result.data as DomainContextConfig, errors: [], warnings };
+  return { valid: true, data: result.data as ProjectContextConfig, errors: [], warnings };
 }
 
 // ---------------------------------------------------------------------------
@@ -168,9 +168,9 @@ export function validateTemplate(data: unknown, stepRegistry?: StepRegistryLike)
   }
 
   // Semantic: domain context checks
-  const dcResult = validateDomainContextConfig(template.domainContext);
-  if (dcResult.warnings.length > 0) {
-    warnings.push(...dcResult.warnings);
+  const projectResult = validateProjectContextConfig(template.project);
+  if (projectResult.warnings.length > 0) {
+    warnings.push(...projectResult.warnings);
   }
 
   // Semantic: custom backend without config

--- a/packages/domain-context/src/template/schema/template-schema.test.ts
+++ b/packages/domain-context/src/template/schema/template-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   AgentTemplateSchema,
-  DomainContextSchema,
+  ProjectContextSchema,
   McpServerRefSchema,
 } from "./template-schema";
 
@@ -17,7 +17,7 @@ const VALID_TEMPLATE = {
     type: "anthropic" as const,
     config: { apiKeyEnv: "ANTHROPIC_API_KEY" },
   },
-  domainContext: {
+  project: {
     skills: ["code-review", "typescript-expert"],
     prompts: ["system-code-reviewer"],
     mcpServers: [
@@ -47,7 +47,7 @@ const MINIMAL_TEMPLATE = {
   version: "0.1.0",
   backend: { type: "cursor" as const },
   provider: { type: "openai" as const },
-  domainContext: {},
+  project: {},
 };
 
 describe("AgentTemplateSchema", () => {
@@ -57,8 +57,8 @@ describe("AgentTemplateSchema", () => {
     if (result.success) {
       expect(result.data.name).toBe("code-review-agent");
       expect(result.data.version).toBe("1.0.0");
-      expect(result.data.domainContext.skills).toEqual(["code-review", "typescript-expert"]);
-      expect(result.data.domainContext.mcpServers).toHaveLength(1);
+      expect(result.data.project.skills).toEqual(["code-review", "typescript-expert"]);
+      expect(result.data.project.mcpServers).toHaveLength(1);
     }
   });
 
@@ -67,10 +67,10 @@ describe("AgentTemplateSchema", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.name).toBe("minimal");
-      expect(result.data.domainContext.skills).toEqual([]);
-      expect(result.data.domainContext.prompts).toEqual([]);
-      expect(result.data.domainContext.mcpServers).toEqual([]);
-      expect(result.data.domainContext.subAgents).toEqual([]);
+      expect(result.data.project.skills).toEqual([]);
+      expect(result.data.project.prompts).toEqual([]);
+      expect(result.data.project.mcpServers).toEqual([]);
+      expect(result.data.project.subAgents).toEqual([]);
       expect(result.data.description).toBeUndefined();
       expect(result.data.initializer).toBeUndefined();
       expect(result.data.metadata).toBeUndefined();
@@ -151,9 +151,9 @@ describe("AgentTemplateSchema", () => {
     }
   });
 
-  it("rejects missing domainContext", () => {
-    const { domainContext: _, ...noDC } = MINIMAL_TEMPLATE;
-    const result = AgentTemplateSchema.safeParse(noDC);
+  it("rejects missing project", () => {
+    const { project: _, ...noProject } = MINIMAL_TEMPLATE;
+    const result = AgentTemplateSchema.safeParse(noProject);
     expect(result.success).toBe(false);
   });
 
@@ -225,9 +225,9 @@ describe("AgentTemplateSchema", () => {
   });
 });
 
-describe("DomainContextSchema", () => {
+describe("ProjectContextSchema", () => {
   it("applies defaults for all optional arrays", () => {
-    const result = DomainContextSchema.safeParse({});
+    const result = ProjectContextSchema.safeParse({});
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.skills).toEqual([]);
@@ -238,8 +238,8 @@ describe("DomainContextSchema", () => {
     }
   });
 
-  it("accepts full domain context", () => {
-    const result = DomainContextSchema.safeParse({
+  it("accepts full project context", () => {
+    const result = ProjectContextSchema.safeParse({
       skills: ["a", "b"],
       prompts: ["p1"],
       mcpServers: [{ name: "fs", command: "npx", args: ["-y", "fs-server"] }],

--- a/packages/domain-context/src/template/schema/template-schema.ts
+++ b/packages/domain-context/src/template/schema/template-schema.ts
@@ -9,7 +9,7 @@ export const McpServerRefSchema = z.object({
   env: z.record(z.string(), z.string()).optional().default({}),
 });
 
-export const DomainContextSchema = z.object({
+export const ProjectContextSchema = z.object({
   skills: z.array(z.string()).optional().default([]),
   prompts: z.array(z.string()).optional().default([]),
   mcpServers: z.array(McpServerRefSchema).optional().default([]),
@@ -137,7 +137,7 @@ export const AgentTemplateSchema = z
     tags: z.array(z.string()).optional(),
     backend: AgentBackendSchema,
     provider: ModelProviderSchema.optional(),
-    domainContext: DomainContextSchema,
+    project: ProjectContextSchema,
     permissions: PermissionsInputSchema.optional(),
     initializer: InitializerSchema.optional(),
     schedule: ScheduleConfigSchema.optional(),

--- a/packages/domain-context/src/template/schema/type-alignment.test.ts
+++ b/packages/domain-context/src/template/schema/type-alignment.test.ts
@@ -3,7 +3,7 @@ import type {
   AgentTemplate,
   AgentBackendConfig,
   ModelProviderConfig,
-  DomainContextConfig,
+  ProjectContextConfig,
   McpServerRef,
   InitializerConfig,
 } from "@actant/shared";
@@ -27,12 +27,12 @@ describe("Schema type alignment with shared types", () => {
     expectTypeOf<SchemaProvider>().toMatchTypeOf<ModelProviderConfig>();
   });
 
-  it("schema domainContext matches DomainContextConfig", () => {
-    expectTypeOf<AgentTemplateOutput["domainContext"]>().toMatchTypeOf<DomainContextConfig>();
+  it("schema project matches ProjectContextConfig", () => {
+    expectTypeOf<AgentTemplateOutput["project"]>().toMatchTypeOf<ProjectContextConfig>();
   });
 
   it("schema mcpServers item matches McpServerRef", () => {
-    type SchemaServer = NonNullable<AgentTemplateOutput["domainContext"]["mcpServers"]>[number];
+    type SchemaServer = NonNullable<AgentTemplateOutput["project"]["mcpServers"]>[number];
     expectTypeOf<SchemaServer>().toMatchTypeOf<McpServerRef>();
   });
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@actant/api": "workspace:0.5.0",
-    "@actant/context": "workspace:0.5.0",
     "@actant/shared": "workspace:0.5.0",
     "@actant/vfs": "workspace:0.5.0",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/mcp-server/src/context-backend.test.ts
+++ b/packages/mcp-server/src/context-backend.test.ts
@@ -44,7 +44,7 @@ describe("createStandaloneContext", () => {
         version: "1.0.0",
         backend: { type: "claude-code" },
         provider: { type: "anthropic" },
-        domainContext: {
+        project: {
           skills: ["bootstrap"],
         },
       }, null, 2),

--- a/packages/mcp-server/src/context-backend.ts
+++ b/packages/mcp-server/src/context-backend.ts
@@ -4,7 +4,6 @@ import {
   createProjectContextRegistrations,
   loadProjectContext,
 } from "@actant/api";
-import { ContextManager, DomainContextSource } from "@actant/context";
 import type {
   VfsDescribeRpcResult,
   VfsGrepRpcResult,
@@ -39,7 +38,6 @@ export interface StandaloneContext extends ContextBackend {
   readonly mode: "standalone";
   readonly projectRoot: string;
   readonly configPath: string | null;
-  readonly contextManager: ContextManager;
 }
 
 export async function createContextBackend(options?: ContextBackendOptions): Promise<ContextBackend> {
@@ -148,20 +146,10 @@ export async function createStandaloneContext(projectDir?: string): Promise<Stan
     }),
   }, "/daemon", { type: "daemon" }));
 
-  const contextManager = new ContextManager();
-  contextManager.registerSource(new DomainContextSource({
-    skillManager: context.managers.skillManager,
-    promptManager: context.managers.promptManager,
-    mcpConfigManager: context.managers.mcpConfigManager,
-    workflowManager: context.managers.workflowManager,
-    templateRegistry: context.managers.templateRegistry,
-  }));
-
   return {
     mode: "standalone",
     projectRoot: context.projectRoot,
     configPath: context.configPath,
-    contextManager,
     async read(path, startLine, endLine) {
       const resolved = registry.resolve(path);
       if (!resolved) {

--- a/packages/shared/src/types/hook.types.ts
+++ b/packages/shared/src/types/hook.types.ts
@@ -61,7 +61,7 @@
  *  Registration Methods
  * ═══════════════════════════════════════════════════════════════
  *
- *  1. Declarative — Workflow JSON loaded from DomainContext
+ *  1. Declarative — Workflow JSON loaded from project context
  *     or actant-hub packages.
  *  2. Programmatic — HookRegistry.registerWorkflow() from system
  *     code or plugin initializers.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -45,9 +45,9 @@ export type {
   PermissionsInput,
 } from "./template.types";
 export type {
-  DomainContextConfig,
+  ProjectContextConfig,
   McpServerRef,
-} from "./domain-context.types";
+} from "./project-context.types";
 export type {
   VersionedComponent,
   ComponentOrigin,

--- a/packages/shared/src/types/project-context.types.ts
+++ b/packages/shared/src/types/project-context.types.ts
@@ -1,4 +1,4 @@
-export interface DomainContextConfig {
+export interface ProjectContextConfig {
   skills?: string[];
   prompts?: string[];
   mcpServers?: McpServerRef[];

--- a/packages/shared/src/types/template.types.ts
+++ b/packages/shared/src/types/template.types.ts
@@ -1,4 +1,4 @@
-import type { DomainContextConfig } from "./domain-context.types";
+import type { ProjectContextConfig } from "./project-context.types";
 import type { VersionedComponent } from "./domain-component.types";
 import type { LaunchMode } from "./agent.types";
 
@@ -48,7 +48,7 @@ export interface AgentTemplate extends VersionedComponent {
   backend: AgentBackendConfig;
   /** Model provider. Optional — when omitted, uses the default provider from config.json. */
   provider?: ModelProviderConfig;
-  domainContext: DomainContextConfig;
+  project: ProjectContextConfig;
   /** Tool/file/network permission control, aligned with Claude Code permissions. */
   permissions?: PermissionsInput;
   initializer?: InitializerConfig;

--- a/packages/shared/src/types/validation.types.ts
+++ b/packages/shared/src/types/validation.types.ts
@@ -7,7 +7,7 @@ export type ValidationSeverity = "error" | "warning" | "info";
 
 /** A single validation issue with path, message, and severity. */
 export interface ValidationIssue {
-  /** Dot-separated path to the problematic field (e.g. "domainContext.skills") */
+  /** Dot-separated path to the problematic field (e.g. "project.skills") */
   path: string;
   message: string;
   severity: ValidationSeverity;

--- a/packages/source/src/source-manager.test.ts
+++ b/packages/source/src/source-manager.test.ts
@@ -58,7 +58,7 @@ async function createLocalPackage(dir: string) {
       version: "1.0.0",
       backend: { type: "cursor" },
       provider: { type: "anthropic" },
-      domainContext: {},
+      project: {},
     }),
   );
 }
@@ -218,12 +218,12 @@ describe("SourceManager", () => {
         version: "1.0.0",
         backend: { type: "cursor" as const },
         provider: { type: "anthropic" as const },
-        domainContext: {},
+        project: {},
       };
 
       const result = sourceMgr.applyPreset("p@test-bundle", template);
-      expect(result.domainContext.skills).toContain("p@test-skill");
-      expect(result.domainContext.prompts).toContain("p@test-prompt");
+      expect(result.project.skills).toContain("p@test-skill");
+      expect(result.project.prompts).toContain("p@test-prompt");
       expect(result.name).toBe("test-tmpl");
     });
 
@@ -233,7 +233,7 @@ describe("SourceManager", () => {
         version: "1.0.0",
         backend: { type: "cursor" as const },
         provider: { type: "anthropic" as const },
-        domainContext: {},
+        project: {},
       };
       expect(() => sourceMgr.applyPreset("nope@missing", template)).toThrow(/not found/);
     });
@@ -247,10 +247,10 @@ describe("SourceManager", () => {
         version: "1.0.0",
         backend: { type: "cursor" as const },
         provider: { type: "anthropic" as const },
-        domainContext: {},
+        project: {},
       };
       const result = sourceMgr.applyPreset("p@template-preset", template);
-      expect(result.domainContext.skills).toContain("p@test-skill");
+      expect(result.project.skills).toContain("p@test-skill");
       expect(managers.templateRegistry.get("p@test-template")).toBeDefined();
     });
   });

--- a/packages/source/src/source-manager.ts
+++ b/packages/source/src/source-manager.ts
@@ -173,7 +173,7 @@ export class SourceManager {
 
   /**
    * Apply a preset to a template — expands preset component refs
-   * into the template's domainContext with `package@name` namespacing.
+   * into the template's project context with `package@name` namespacing.
    * Returns a new template (does not mutate input).
    */
   applyPreset(qualifiedName: string, template: AgentTemplate): AgentTemplate {
@@ -185,12 +185,12 @@ export class SourceManager {
     const packageName = qualifiedName.split("@")[0];
     const ns = (name: string) => `${packageName}@${name}`;
 
-    const dc = { ...template.domainContext };
+    const project = { ...template.project };
     if (preset.skills?.length) {
-      dc.skills = [...(dc.skills ?? []), ...preset.skills.map(ns)];
+      project.skills = [...(project.skills ?? []), ...preset.skills.map(ns)];
     }
     if (preset.prompts?.length) {
-      dc.prompts = [...(dc.prompts ?? []), ...preset.prompts.map(ns)];
+      project.prompts = [...(project.prompts ?? []), ...preset.prompts.map(ns)];
     }
     if (preset.mcpServers?.length) {
       const newRefs = preset.mcpServers.map((mcpName: string) => {
@@ -203,12 +203,12 @@ export class SourceManager {
           env: existing?.env,
         };
       });
-      dc.mcpServers = [...(dc.mcpServers ?? []), ...newRefs];
+      project.mcpServers = [...(project.mcpServers ?? []), ...newRefs];
     }
     if (preset.workflows?.length) {
       const firstWorkflow = preset.workflows[0];
-      if (firstWorkflow && !dc.workflow) {
-        dc.workflow = ns(firstWorkflow);
+      if (firstWorkflow && !project.workflow) {
+        project.workflow = ns(firstWorkflow);
       }
     }
     if (preset.templates?.length && this.managers.templateRegistry) {
@@ -221,7 +221,7 @@ export class SourceManager {
       }
     }
 
-    return { ...template, domainContext: dc };
+    return { ...template, project };
   }
 
   // ---------------------------------------------------------------------------
@@ -308,16 +308,16 @@ export class SourceManager {
     if (this.managers.templateRegistry && result.templates.length > 0) {
       const nsRef = (ref: string) => ref.includes("@") ? ref : `${packageName}@${ref}`;
       for (const template of result.templates) {
-        const dc = template.domainContext;
+        const project = template.project;
         const nsTemplate = {
           ...template,
           name: `${packageName}@${template.name}`,
-          domainContext: {
-            ...dc,
-            skills: dc.skills?.map(nsRef),
-            prompts: dc.prompts?.map(nsRef),
-            subAgents: dc.subAgents?.map(nsRef),
-            workflow: dc.workflow ? nsRef(dc.workflow) : dc.workflow,
+          project: {
+            ...project,
+            skills: project.skills?.map(nsRef),
+            prompts: project.prompts?.map(nsRef),
+            subAgents: project.subAgents?.map(nsRef),
+            workflow: project.workflow ? nsRef(project.workflow) : project.workflow,
           },
         };
         this.managers.templateRegistry.register(nsTemplate);

--- a/packages/source/src/source-validator.test.ts
+++ b/packages/source/src/source-validator.test.ts
@@ -70,7 +70,7 @@ describe("SourceValidator", () => {
       version: "1.0.0",
       description: "A template",
       backend: { type: "claude-code" },
-      domainContext: { skills: ["my-skill"], prompts: ["my-prompt"] },
+      project: { skills: ["my-skill"], prompts: ["my-prompt"] },
     };
     await writeFile(join(tmpDir, "templates/my-tpl.json"), JSON.stringify(template));
 
@@ -223,7 +223,7 @@ describe("SourceValidator", () => {
   describe("template validation", () => {
     it("reports error for template missing backend", async () => {
       await createMinimalSource({
-        template: { name: "bad-tpl", version: "1.0.0", domainContext: {} },
+        template: { name: "bad-tpl", version: "1.0.0", project: {} },
       });
       const report = await validator.validate(tmpDir);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
 
   packages/agent-runtime:
     dependencies:
-      '@actant/context':
-        specifier: workspace:0.5.0
-        version: link:../context
       '@actant/domain-context':
         specifier: workspace:0.5.0
         version: link:../domain-context
@@ -135,9 +132,6 @@ importers:
       '@actant/channel-claude':
         specifier: workspace:0.5.0
         version: link:../channel-claude
-      '@actant/context':
-        specifier: workspace:0.5.0
-        version: link:../context
       '@actant/pi':
         specifier: workspace:0.5.0
         version: link:../pi
@@ -302,9 +296,6 @@ importers:
       '@actant/api':
         specifier: workspace:0.5.0
         version: link:../api
-      '@actant/context':
-        specifier: workspace:0.5.0
-        version: link:../context
       '@actant/shared':
         specifier: workspace:0.5.0
         version: link:../shared

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,24 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@actant/shared": ["packages/shared/src/index.ts"],
+      "@actant/context": ["packages/context/src/index.ts"],
+      "@actant/domain-context": ["packages/domain-context/src/index.ts"],
+      "@actant/source": ["packages/source/src/index.ts"],
+      "@actant/vfs": ["packages/vfs/src/index.ts"],
+      "@actant/agent-runtime": ["packages/agent-runtime/src/index.ts"],
+      "@actant/api": ["packages/api/src/index.ts"],
+      "@actant/rest-api": ["packages/rest-api/src/index.ts"],
+      "@actant/acp": ["packages/acp/src/index.ts"],
+      "@actant/channel-claude": ["packages/channel-claude/src/index.ts"],
+      "@actant/mcp-server": ["packages/mcp-server/src/index.ts"],
+      "@actant/pi": ["packages/pi/src/index.ts"],
+      "@actant/tui": ["packages/tui/src/index.ts"],
+      "@actant/tui/testing": ["packages/tui/src/testing.ts"],
+      "@actant/cli": ["packages/cli/src/index.ts"],
+      "@actant/actant": ["packages/actant/src/index.ts"]
+    },
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- replace active domainContext contracts with project/projectContext naming
- remove active ContextManager-based aggregation from API and MCP runtime paths
- update specs, snapshots, and lockfile so repo-level verification stays green

## Verification
- pnpm type-check
- pnpm lint
- pnpm test