### PR TITLE
feat: complete M3 project manifest orchestration

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,6 +43,7 @@
     "@actant/acp": "workspace:0.5.0",
     "@actant/channel-claude": "workspace:0.5.0",
     "@actant/agent-runtime": "workspace:0.5.0",
+    "@actant/context": "workspace:0.5.0",
     "@actant/pi": "workspace:0.5.0",
     "@actant/shared": "workspace:0.5.0"
   }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,6 +2,8 @@ export { Daemon } from "./daemon/index";
 export { AppContext, type AppConfig } from "./services/app-context";
 export {
   loadProjectContext,
+  buildProjectScopeSnapshot,
+  createProjectContextPermissionRules,
   createProjectContextFactoryRegistry,
   createProjectContextRegistrations,
   type LoadedProjectContext,

--- a/packages/api/src/services/hub-context.ts
+++ b/packages/api/src/services/hub-context.ts
@@ -6,12 +6,14 @@ import type {
   VfsSourceRegistration,
 } from "@actant/shared";
 import {
+  createProjectContextPermissionRules,
   createProjectContextFactoryRegistry,
   createProjectContextRegistrations,
   loadProjectContext,
   type LoadedProjectContext,
 } from "./project-context";
 import type { AppContext } from "./app-context";
+import { DEFAULT_PERMISSION_RULES } from "@actant/agent-runtime";
 
 const HUB_LAYOUT = {
   project: "/hub/project",
@@ -100,6 +102,10 @@ export class HubContextService {
   private async doActivate(projectDir?: string): Promise<HubActivateResult> {
     const context = await loadProjectContext(projectDir);
     const registrations = buildHubRegistrations(context, this.factoryRegistry);
+    this.appContext.vfsPermissionManager.setRules([
+      ...DEFAULT_PERMISSION_RULES,
+      ...createProjectContextPermissionRules(context, { project: HUB_LAYOUT.project }),
+    ]);
     await this.replaceActiveContext(registrations);
 
     const next: ActiveHubContext = {

--- a/packages/api/src/services/project-context.ts
+++ b/packages/api/src/services/project-context.ts
@@ -1,6 +1,12 @@
 import { access, readFile, stat } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import {
+  createProjectManifestRegistrations,
+  compileProjectPermissionRules,
+  resolveProjectPermissionConfig,
+  type ProjectScopeSnapshot,
+} from "@actant/context";
 import {
   SkillManager,
   PromptManager,
@@ -19,11 +25,16 @@ import type {
   AgentTemplate,
   ActantProjectEntrypoints,
   ActantProjectConfig,
+  ChildProjectRef,
+  PermissionConfig,
+  ProjectManifest,
   ProjectSourceEntry,
   SourceConfig,
+  VfsPermissionRule,
   VfsLifecycle,
   VfsSourceRegistration,
 } from "@actant/shared";
+import { ensureWithinWorkspace } from "@actant/shared";
 
 export interface ProjectContextSummary {
   mode: "project-context";
@@ -52,14 +63,25 @@ export interface ProjectContextSummary {
     workflows: number;
     templates: number;
   };
+  manifest: ProjectManifest;
+  effectivePermissions: PermissionConfig;
+  children: Array<{
+    name: string;
+    projectRoot: string;
+    manifestPath: string | null;
+  }>;
 }
 
 export interface LoadedProjectContext {
+  mountName: string;
   projectRoot: string;
   configPath: string | null;
   configsDir: string;
   configExists: boolean;
   projectConfig: ActantProjectConfig;
+  projectManifest: ProjectManifest;
+  effectivePermissions: PermissionConfig;
+  children: LoadedProjectContext[];
   summary: ProjectContextSummary;
   managers: {
     skillManager: SkillManager;
@@ -88,11 +110,83 @@ export interface ProjectContextRegistrationOptions {
 }
 
 export async function loadProjectContext(projectDir?: string): Promise<LoadedProjectContext> {
+  return loadProjectContextInternal(projectDir, {
+    visitedManifestPaths: new Set<string>(),
+  });
+}
+
+export function buildProjectScopeSnapshot(context: LoadedProjectContext): ProjectScopeSnapshot {
+  return {
+    name: context.mountName,
+    projectRoot: context.projectRoot,
+    manifestPath: context.configPath,
+    manifest: context.projectManifest,
+    effectivePermissions: context.effectivePermissions,
+    children: context.children.map((child) => buildProjectScopeSnapshot(child)),
+  };
+}
+
+export function createProjectContextPermissionRules(
+  context: LoadedProjectContext,
+  layout: Pick<ProjectContextMountLayout, "project">,
+): VfsPermissionRule[] {
+  return compileProjectPermissionRules(
+    buildProjectScopeSnapshot(context),
+    deriveProjectScopeRoot(layout.project),
+  );
+}
+
+export function createProjectContextRegistrations(
+  context: LoadedProjectContext,
+  factoryRegistry: SourceFactoryRegistry,
+  layout: ProjectContextMountLayout,
+  lifecycle: VfsLifecycle,
+  options?: ProjectContextRegistrationOptions,
+): VfsSourceRegistration[] {
+  const prefix = options?.namePrefix ?? "project-context";
+  const regs: VfsSourceRegistration[] = [
+    ...createProjectManifestRegistrations(
+      buildProjectScopeSnapshot(context),
+      lifecycle,
+      deriveProjectScopeRoot(layout.project),
+      `${prefix}-scope`,
+    ),
+    ...createProjectRegistrationsForScope(
+      context,
+      factoryRegistry,
+      layout,
+      lifecycle,
+      prefix,
+      options,
+    ),
+  ];
+
+  return regs;
+}
+
+async function loadProjectContextInternal(
+  projectDir: string | undefined,
+  options: {
+    inheritedPermissions?: PermissionConfig;
+    mountNameOverride?: string;
+    visitedManifestPaths: Set<string>;
+  },
+): Promise<LoadedProjectContext> {
   const rootResolution = await resolveProjectRoot(projectDir);
   const projectRoot = rootResolution.projectRoot;
   const projectConfigResult = await loadProjectConfig(projectRoot);
+  const visitedManifestPaths = new Set(options.visitedManifestPaths);
+  if (projectConfigResult.path) {
+    visitedManifestPaths.add(projectConfigResult.path);
+  }
   const projectConfig = projectConfigResult.config;
+  const projectName = projectConfig.name ?? basename(projectRoot);
+  const mountName = options.mountNameOverride ?? projectName;
   const configsDir = resolve(projectRoot, projectConfig.configsDir ?? "configs");
+  const effectivePermissions = resolveProjectPermissionConfig(
+    projectConfig.permissions,
+    options.inheritedPermissions,
+  );
 
   const skillManager = new SkillManager();
   const promptManager = new PromptManager();
@@ -154,21 +248,40 @@ export async function loadProjectContext(projectDir?: string): Promise<LoadedPro
   sourceWarnings.push(...entrypointInfo.warnings);
 
   const available = {
-    skills: sortNames(skillManager.list().map((skill) => skill.name)),
-    prompts: sortNames(promptManager.list().map((prompt) => prompt.name)),
-    mcpServers: sortNames(mcpConfigManager.list().map((server) => server.name)),
-    workflows: sortNames(workflowManager.list().map((workflow) => workflow.name)),
-    templates: sortNames(templateRegistry.list().map((template) => template.name)),
+    skills: sortNames(skillManager.list().map((skill: { name: string }) => skill.name)),
+    prompts: sortNames(promptManager.list().map((prompt: { name: string }) => prompt.name)),
+    mcpServers: sortNames(mcpConfigManager.list().map((server: { name: string }) => server.name)),
+    workflows: sortNames(workflowManager.list().map((workflow: { name: string }) => workflow.name)),
+    templates: sortNames(templateRegistry.list().map((template: { name: string }) => template.name)),
   };
 
+  const childProjects = await loadChildProjects(
+    projectRoot,
+    projectConfig.children ?? [],
+    effectivePermissions,
+    visitedManifestPaths,
+  );
+  sourceWarnings.push(...childProjects.warnings);
+
+  const projectManifest = buildProjectManifest(
+    projectName,
+    projectConfig,
+    buildProjectMountDeclarations(projectRoot, configsDir, await pathExists(configsDir)),
+  );
+
   return {
+    mountName,
     projectRoot,
     configPath: projectConfigResult.path,
     configsDir,
     configExists: await pathExists(configsDir),
     projectConfig,
+    projectManifest,
+    effectivePermissions,
+    children: childProjects.contexts,
     summary: buildProjectContextSummary(
       projectRoot,
+      projectName,
       projectConfigResult.path,
       configsDir,
       projectConfig,
@@ -183,6 +296,9 @@ export async function loadProjectContext(projectDir?: string): Promise<LoadedPro
         workflows: available.workflows.length,
         templates: available.templates.length,
       },
+      projectManifest,
+      effectivePermissions,
+      childProjects.contexts,
     ),
     managers: {
       skillManager,
@@ -192,41 +308,6 @@ export async function loadProjectContext(projectDir?: string): Promise<LoadedPro
       templateRegistry,
     },
   };
-}
-
-export function createProjectContextRegistrations(
-  context: LoadedProjectContext,
-  factoryRegistry: SourceFactoryRegistry,
-  layout: ProjectContextMountLayout,
-  lifecycle: VfsLifecycle,
-  options?: ProjectContextRegistrationOptions,
-): VfsSourceRegistration[] {
-  const prefix = options?.namePrefix ?? "project-context";
-  const regs: VfsSourceRegistration[] = [
-    createProjectSource(`${prefix}-project`, context, layout.project, lifecycle),
-    factoryRegistry.create({
-      name: `${prefix}-workspace`,
-      mountPoint: layout.workspace,
-      spec: { type: "filesystem", path: context.projectRoot, readOnly: options?.workspaceReadOnly ?? false },
-      lifecycle,
-    }),
-    createDomainSource(context.managers.skillManager, `${prefix}-skills`, layout.skills, lifecycle),
-    createDomainSource(context.managers.promptManager, `${prefix}-prompts`, layout.prompts, lifecycle),
-    createDomainSource(context.managers.mcpConfigManager, `${prefix}-mcp`, layout.mcp, lifecycle),
-    createDomainSource(context.managers.workflowManager, `${prefix}-workflows`, layout.workflows, lifecycle),
-    createDomainSource(context.managers.templateRegistry, `${prefix}-templates`, layout.templates, lifecycle),
-  ];
-
-  if (context.configExists) {
-    regs.splice(2, 0, factoryRegistry.create({
-      name: `${prefix}-config`,
-      mountPoint: layout.config,
-      spec: { type: "filesystem", path: context.configsDir, readOnly: options?.configReadOnly ?? false },
-      lifecycle,
-    }));
-  }
-
-  return regs;
 }
 
 export function createProjectContextFactoryRegistry(): SourceFactoryRegistry {
@@ -359,6 +440,7 @@ function injectSourceComponents(
 
 function buildProjectContextSummary(
   projectRoot: string,
+  projectName: string,
   configPath: string | null,
   configsDir: string,
   config: ActantProjectConfig,
@@ -367,11 +449,14 @@ function buildProjectContextSummary(
   entrypoints: ProjectContextSummary["entrypoints"],
   available: ProjectContextSummary["available"],
   counts: ProjectContextSummary["components"],
+  manifest: ProjectManifest,
+  effectivePermissions: PermissionConfig,
+  children: LoadedProjectContext[],
 ): ProjectContextSummary {
   return {
     mode: "project-context",
     projectRoot,
-    projectName: config.name ?? basename(projectRoot),
+    projectName,
     description: config.description,
     configPath,
     configsDir,
@@ -380,7 +465,180 @@ function buildProjectContextSummary(
     entrypoints,
     available,
     components: counts,
+    manifest,
+    effectivePermissions,
+    children: children.map((child) => ({
+      name: child.mountName,
+      projectRoot: child.projectRoot,
+      manifestPath: child.configPath,
+    })),
   };
+}
+
+function buildProjectManifest(
+  projectName: string,
+  config: ActantProjectConfig,
+  mounts: ProjectManifest["mounts"],
+): ProjectManifest {
+  return {
+    name: projectName,
+    mounts,
+    ...(config.permissions ? { permissions: config.permissions } : {}),
+    ...(config.children?.length ? { children: config.children } : {}),
+  };
+}
+
+function buildProjectMountDeclarations(
+  projectRoot: string,
+  configsDir: string,
+  configExists: boolean,
+): ProjectManifest["mounts"] {
+  const mounts: ProjectManifest["mounts"] = [
+    {
+      source: "project",
+      path: "/project",
+    },
+    {
+      source: "workspace",
+      path: "/workspace",
+      config: { path: projectRoot },
+    },
+    {
+      source: "skills",
+      path: "/skills",
+    },
+    {
+      source: "prompts",
+      path: "/prompts",
+    },
+    {
+      source: "mcp",
+      path: "/mcp",
+    },
+    {
+      source: "workflows",
+      path: "/workflows",
+    },
+    {
+      source: "templates",
+      path: "/templates",
+    },
+  ];
+
+  if (configExists) {
+    mounts.splice(1, 0, {
+      source: "config",
+      path: "/config",
+      config: { path: configsDir },
+    });
+  }
+
+  return mounts;
+}
+
+function createProjectRegistrationsForScope(
+  context: LoadedProjectContext,
+  factoryRegistry: SourceFactoryRegistry,
+  layout: ProjectContextMountLayout,
+  lifecycle: VfsLifecycle,
+  prefix: string,
+  options?: ProjectContextRegistrationOptions,
+): VfsSourceRegistration[] {
+  const regs: VfsSourceRegistration[] = [
+    createProjectSource(`${prefix}-project`, context, layout.project, lifecycle),
+    factoryRegistry.create({
+      name: `${prefix}-workspace`,
+      mountPoint: layout.workspace,
+      spec: { type: "filesystem", path: context.projectRoot, readOnly: options?.workspaceReadOnly ?? false },
+      lifecycle,
+    }),
+    createDomainSource(context.managers.skillManager, `${prefix}-skills`, layout.skills, lifecycle),
+    createDomainSource(context.managers.promptManager, `${prefix}-prompts`, layout.prompts, lifecycle),
+    createDomainSource(context.managers.mcpConfigManager, `${prefix}-mcp`, layout.mcp, lifecycle),
+    createDomainSource(context.managers.workflowManager, `${prefix}-workflows`, layout.workflows, lifecycle),
+    createDomainSource(context.managers.templateRegistry, `${prefix}-templates`, layout.templates, lifecycle),
+  ];
+
+  if (context.configExists) {
+    regs.splice(2, 0, factoryRegistry.create({
+      name: `${prefix}-config`,
+      mountPoint: layout.config,
+      spec: { type: "filesystem", path: context.configsDir, readOnly: options?.configReadOnly ?? false },
+      lifecycle,
+    }));
+  }
+
+  for (const child of context.children) {
+    const childLayout = childLayoutForScope(layout, child.mountName);
+    const childPrefix = `${prefix}-${sanitizeMountName(child.mountName)}`;
+    regs.push(
+      ...createProjectRegistrationsForScope(
+        child,
+        factoryRegistry,
+        childLayout,
+        lifecycle,
+        childPrefix,
+        options,
+      ),
+    );
+  }
+
+  return regs;
+}
+
+function childLayoutForScope(
+  layout: ProjectContextMountLayout,
+  childName: string,
+): ProjectContextMountLayout {
+  const scopeRoot = joinMountedPath(deriveProjectScopeRoot(layout.project), "projects", childName);
+  return {
+    project: joinMountedPath(scopeRoot, "project"),
+    workspace: joinMountedPath(scopeRoot, "workspace"),
+    config: joinMountedPath(scopeRoot, "config"),
+    skills: joinMountedPath(scopeRoot, "skills"),
+    prompts: joinMountedPath(scopeRoot, "prompts"),
+    mcp: joinMountedPath(scopeRoot, "mcp"),
+    workflows: joinMountedPath(scopeRoot, "workflows"),
+    templates: joinMountedPath(scopeRoot, "templates"),
+  };
+}
+
+async function loadChildProjects(
+  projectRoot: string,
+  children: ChildProjectRef[],
+  inheritedPermissions: PermissionConfig,
+  visitedManifestPaths: Set<string>,
+): Promise<{
+  contexts: LoadedProjectContext[];
+  warnings: string[];
+}> {
+  const contexts: LoadedProjectContext[] = [];
+  const warnings: string[] = [];
+
+  for (const child of children) {
+    try {
+      const childManifestPath = ensureWithinWorkspace(projectRoot, child.manifest);
+      if (visitedManifestPaths.has(childManifestPath)) {
+        warnings.push(`Child project "${child.name}" creates a manifest cycle at "${child.manifest}"`);
+        continue;
+      }
+
+      const nextVisited = new Set(visitedManifestPaths);
+      nextVisited.add(childManifestPath);
+
+      const context = await loadProjectContextInternal(dirname(childManifestPath), {
+        inheritedPermissions,
+        mountNameOverride: child.name,
+        visitedManifestPaths: nextVisited,
+      });
+      contexts.push(context);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      warnings.push(`Child project "${child.name}" failed: ${msg}`);
+    }
+  }
+
+  return { contexts, warnings };
 }
 
 async function detectRepoLocalSource(
@@ -460,6 +718,8 @@ function createProjectSource(
     configsDir: context.projectConfig.configsDir ?? "configs",
     ...(context.projectConfig.sources ? { sources: context.projectConfig.sources } : {}),
     ...(context.projectConfig.entrypoints ? { entrypoints: context.projectConfig.entrypoints } : {}),
+    ...(context.projectConfig.permissions ? { permissions: context.projectConfig.permissions } : {}),
+    ...(context.projectConfig.children ? { children: context.projectConfig.children } : {}),
   };
 
   return {
@@ -470,7 +730,7 @@ function createProjectSource(
     metadata: { description: "Project-level Actant context (virtual)", virtual: true },
     fileSchema: {},
     handlers: {
-      read: async (filePath) => {
+      read: async (filePath: string) => {
         const normalized = filePath.replace(/^\/+/, "");
         switch (normalized) {
           case "context.json":
@@ -490,7 +750,7 @@ function createProjectSource(
           { name: "sources.json", path: "sources.json", type: "file" as const },
         ];
       },
-      stat: async (filePath) => {
+      stat: async (filePath: string) => {
         const normalized = filePath.replace(/^\/+/, "");
         if (["context.json", "actant.project.json", "sources.json"].includes(normalized)) {
           return { type: "file" as const, size: 0, mtime: new Date().toISOString() };
@@ -525,6 +785,12 @@ function validateProjectConfig(input: unknown):
   }
   if (value.entrypoints !== undefined) {
     warnings.push(...validateProjectEntrypoints(value.entrypoints));
+  }
+  if (value.permissions !== undefined) {
+    warnings.push(...validateProjectPermissions(value.permissions));
+  }
+  if (value.children !== undefined) {
+    warnings.push(...validateChildProjects(value.children));
   }
 
   const sourcesInput = value.sources;
@@ -622,6 +888,83 @@ function validateProjectSourceEntry(source: unknown, index: number): string[] {
   return warnings;
 }
 
+function validateProjectPermissions(permissions: unknown): string[] {
+  if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) {
+    return ["permissions must be an object"];
+  }
+
+  const value = permissions as Record<string, unknown>;
+  const warnings = validatePermissionSet(value.defaults, "permissions.defaults");
+  if (value.rules !== undefined) {
+    if (!Array.isArray(value.rules)) {
+      warnings.push("permissions.rules must be an array");
+    } else {
+      value.rules.forEach((rule, index) => {
+        warnings.push(...validatePermissionRule(rule, index));
+      });
+    }
+  }
+
+  return warnings;
+}
+
+function validateChildProjects(children: unknown): string[] {
+  if (!Array.isArray(children)) {
+    return ["children must be an array"];
+  }
+
+  const warnings: string[] = [];
+  children.forEach((child, index) => {
+    if (!child || typeof child !== "object" || Array.isArray(child)) {
+      warnings.push(`children.${index} must be an object`);
+      return;
+    }
+
+    const value = child as Record<string, unknown>;
+    if (typeof value.name !== "string" || value.name.trim().length === 0) {
+      warnings.push(`children.${index}.name must be a non-empty string`);
+    }
+    if (typeof value.manifest !== "string" || value.manifest.trim().length === 0) {
+      warnings.push(`children.${index}.manifest must be a non-empty string`);
+    }
+  });
+
+  return warnings;
+}
+
+function validatePermissionRule(rule: unknown, index: number): string[] {
+  if (!rule || typeof rule !== "object" || Array.isArray(rule)) {
+    return [`permissions.rules.${index} must be an object`];
+  }
+
+  const value = rule as Record<string, unknown>;
+  const warnings = validatePermissionSet(value, `permissions.rules.${index}`);
+  if (typeof value.agent !== "string" || value.agent.trim().length === 0) {
+    warnings.push(`permissions.rules.${index}.agent must be a non-empty string`);
+  }
+  if (typeof value.path !== "string" || value.path.trim().length === 0) {
+    warnings.push(`permissions.rules.${index}.path must be a non-empty string`);
+  }
+
+  return warnings;
+}
+
+function validatePermissionSet(value: unknown, prefix: string): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [`${prefix} must be an object`];
+  }
+
+  const record = value as Record<string, unknown>;
+  const warnings: string[] = [];
+  for (const field of ["read", "write", "watch", "stream"] as const) {
+    if (record[field] !== undefined && typeof record[field] !== "boolean") {
+      warnings.push(`${prefix}.${field} must be a boolean`);
+    }
+  }
+
+  return warnings;
+}
+
 async function pathExists(filePath: string): Promise<boolean> {
   try {
     await access(filePath);
@@ -673,6 +1016,23 @@ function dedupeStrings(values: string[]): string[] {
 
 function sortNames(values: string[]): string[] {
   return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function deriveProjectScopeRoot(projectMountPath: string): string {
+  const resolved = dirname(projectMountPath);
+  return resolved === "." ? "/" : resolved;
+}
+
+function joinMountedPath(base: string, ...parts: string[]): string {
+  const allParts = [
+    ...base.split("/").filter(Boolean),
+    ...parts.flatMap((part) => part.split("/").filter(Boolean)),
+  ];
+  return allParts.length === 0 ? "/" : `/${allParts.join("/")}`;
+}
+
+function sanitizeMountName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "project";
 }
 
 async function resolveProjectRoot(projectDir?: string): Promise<{

--- a/packages/cli/src/commands/__tests__/commands.test.ts
+++ b/packages/cli/src/commands/__tests__/commands.test.ts
@@ -454,4 +454,135 @@ describe("createHubCommand", () => {
     expect(output.logs.some((line) => line.includes("Project:      repo"))).toBe(true);
     expect(output.logs.some((line) => line.includes("standalone project-context mode"))).toBe(true);
   });
+
+  it("hub read routes the root project manifest through the daemon hub mount", async () => {
+    const mock = createMockClient();
+    mock.ping.mockResolvedValue(true);
+    mock.call
+      .mockResolvedValueOnce({
+        projectRoot: "/repo",
+        projectName: "repo",
+        configPath: null,
+        configsDir: "/repo/configs",
+        sourceWarnings: [],
+        components: { skills: 1, prompts: 0, mcpServers: 0, workflows: 0, templates: 0 },
+        mounts: {
+          project: "/hub/project",
+          workspace: "/hub/workspace",
+          config: "/hub/config",
+          skills: "/hub/skills",
+          prompts: "/hub/prompts",
+          mcp: "/hub/mcp",
+          workflows: "/hub/workflows",
+          templates: "/hub/templates",
+        },
+      })
+      .mockResolvedValueOnce({
+        active: true,
+        hostProfile: "bootstrap",
+        runtimeState: "inactive",
+        projectRoot: "/repo",
+        projectName: "repo",
+        configPath: null,
+        configsDir: "/repo/configs",
+        sourceWarnings: [],
+        components: { skills: 1, prompts: 0, mcpServers: 0, workflows: 0, templates: 0 },
+        mounts: {
+          project: "/hub/project",
+          workspace: "/hub/workspace",
+          config: "/hub/config",
+          skills: "/hub/skills",
+          prompts: "/hub/prompts",
+          mcp: "/hub/mcp",
+          workflows: "/hub/workflows",
+          templates: "/hub/templates",
+        },
+      })
+      .mockResolvedValueOnce({
+        content: "{\"name\":\"repo\"}",
+        mimeType: "application/json",
+      });
+
+    const client = mock as unknown as RpcClient;
+    const { printer } = createTestPrinter();
+    const parent = new Command();
+    parent.exitOverride();
+    parent.addCommand(createHubCommand(client, printer));
+
+    await parent.parseAsync(["node", "test", "hub", "read", "/_project.json"]);
+
+    expect(mock.call).toHaveBeenNthCalledWith(3, "vfs.read", {
+      path: "/hub/_project.json",
+      startLine: undefined,
+      endLine: undefined,
+      token: undefined,
+    });
+  });
+
+  it("hub list routes child project paths through the daemon hub mount", async () => {
+    const mock = createMockClient();
+    mock.ping.mockResolvedValue(true);
+    mock.call
+      .mockResolvedValueOnce({
+        projectRoot: "/repo",
+        projectName: "repo",
+        configPath: null,
+        configsDir: "/repo/configs",
+        sourceWarnings: [],
+        components: { skills: 1, prompts: 0, mcpServers: 0, workflows: 0, templates: 0 },
+        mounts: {
+          project: "/hub/project",
+          workspace: "/hub/workspace",
+          config: "/hub/config",
+          skills: "/hub/skills",
+          prompts: "/hub/prompts",
+          mcp: "/hub/mcp",
+          workflows: "/hub/workflows",
+          templates: "/hub/templates",
+        },
+      })
+      .mockResolvedValueOnce({
+        active: true,
+        hostProfile: "bootstrap",
+        runtimeState: "inactive",
+        projectRoot: "/repo",
+        projectName: "repo",
+        configPath: null,
+        configsDir: "/repo/configs",
+        sourceWarnings: [],
+        components: { skills: 1, prompts: 0, mcpServers: 0, workflows: 0, templates: 0 },
+        mounts: {
+          project: "/hub/project",
+          workspace: "/hub/workspace",
+          config: "/hub/config",
+          skills: "/hub/skills",
+          prompts: "/hub/prompts",
+          mcp: "/hub/mcp",
+          workflows: "/hub/workflows",
+          templates: "/hub/templates",
+        },
+      })
+      .mockResolvedValueOnce([
+        {
+          name: "child",
+          path: "/hub/projects/child",
+          type: "directory",
+        },
+      ]);
+
+    const client = mock as unknown as RpcClient;
+    const { printer } = createTestPrinter();
+    const parent = new Command();
+    parent.exitOverride();
+    parent.addCommand(createHubCommand(client, printer));
+
+    await parent.parseAsync(["node", "test", "hub", "list", "/projects/child"]);
+
+    expect(mock.call).toHaveBeenNthCalledWith(3, "vfs.list", {
+      path: "/hub/projects/child",
+      recursive: undefined,
+      long: undefined,
+      token: undefined,
+    });
+  });
 });

--- a/packages/cli/src/commands/hub/index.ts
+++ b/packages/cli/src/commands/hub/index.ts
@@ -21,7 +21,9 @@ import { ensureDaemonRunning } from "../daemon/start";
 import { presentError, type CliPrinter, defaultPrinter, type OutputFormat } from "../../output/index";
 
 const HUB_ALIASES: Record<string, string> = {
+  "/_project.json": "/hub/_project.json",
   "/project": "/hub/project",
+  "/projects": "/hub/projects",
   "/workspace": "/hub/workspace",
   "/config": "/hub/config",
   "/skills": "/hub/skills",
@@ -300,7 +302,22 @@ async function createStandaloneHubBackend(projectDir: string): Promise<HubBacken
         }));
       }
       const handler = requireHandler(resolved.source.handlers.list, "list", path);
-      return handler(resolved.relativePath, { recursive, long });
+      const entries = await handler(resolved.relativePath, { recursive, long });
+      if (resolved.relativePath !== "") {
+        return entries;
+      }
+
+      const childMounts = registry.listChildMounts(path);
+      const projectedMounts = childMounts.map((source) => ({
+        name: source.mountPoint.split("/").pop() ?? source.name,
+        path: source.mountPoint,
+        type: "directory" as const,
+      }));
+      const deduped = new Map<string, (typeof entries)[number]>();
+      for (const entry of [...entries, ...projectedMounts]) {
+        deduped.set(entry.path, entry);
+      }
+      return [...deduped.values()];
     },
     async grep(pattern, path = "/hub/workspace", caseInsensitive, maxResults) {
       const resolved = registry.resolve(path);

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -12,6 +12,14 @@ export {
 } from "./manager/context-manager";
 
 export {
+  createProjectManifestRegistrations,
+  compileProjectPermissionRules,
+  resolveProjectPermissionConfig,
+  type ProjectScopeSnapshot,
+  type ProjectManifestProjection,
+} from "./project/project-manifest";
+
+export {
   DomainContextSource,
   type DomainManagers,
   type DomainComponentManager,

--- a/packages/context/src/project/project-manifest.ts
+++ b/packages/context/src/project/project-manifest.ts
@@ -1,0 +1,431 @@
+import type {
+  PermissionConfig,
+  PermissionSet,
+  ProjectManifest,
+  VfsCapabilityId,
+  VfsEntry,
+  VfsLifecycle,
+  VfsPermissionRule,
+  VfsSourceRegistration,
+  VfsStatResult,
+} from "@actant/shared";
+
+const FULL_PROJECT_ACCESS: PermissionConfig = {
+  defaults: {
+    read: true,
+    write: true,
+    watch: true,
+    stream: true,
+  },
+};
+
+const READ_ACTIONS: VfsCapabilityId[] = [
+  "read",
+  "read_range",
+  "list",
+  "stat",
+  "tree",
+  "glob",
+  "grep",
+  "semantic_search",
+  "read_lints",
+];
+
+const WRITE_ACTIONS: VfsCapabilityId[] = [
+  "write",
+  "edit",
+  "delete",
+  "edit_notebook",
+];
+
+const WATCH_ACTIONS: VfsCapabilityId[] = [
+  "watch",
+  "on_change",
+];
+
+const STREAM_ACTIONS: VfsCapabilityId[] = [
+  "read",
+  "read_range",
+];
+
+export interface ProjectScopeSnapshot {
+  name: string;
+  projectRoot: string;
+  manifestPath: string | null;
+  manifest: ProjectManifest;
+  effectivePermissions: PermissionConfig;
+  children: ProjectScopeSnapshot[];
+}
+
+export interface ProjectManifestProjection {
+  name: string;
+  projectRoot: string;
+  manifestPath: string | null;
+  mountPoint: string;
+  manifest: ProjectManifest;
+  effectivePermissions: PermissionConfig;
+  children: Array<{
+    name: string;
+    mountPoint: string;
+    projectRoot: string;
+    manifestPath: string | null;
+  }>;
+}
+
+export function resolveProjectPermissionConfig(
+  permissionConfig: PermissionConfig | undefined,
+  inherited: PermissionConfig | undefined,
+): PermissionConfig {
+  const base = inherited ?? FULL_PROJECT_ACCESS;
+  if (!permissionConfig) {
+    return {
+      defaults: { ...base.defaults },
+      ...(base.rules?.length
+        ? { rules: base.rules.map((rule: NonNullable<PermissionConfig["rules"]>[number]) => ({ ...rule })) }
+        : {}),
+    };
+  }
+
+  const defaults = narrowPermissionSet(base.defaults, permissionConfig.defaults);
+  const rules = permissionConfig.rules?.map((rule: NonNullable<PermissionConfig["rules"]>[number]) => ({
+    ...rule,
+    ...narrowPermissionSet(defaults, rule),
+  }));
+
+  return {
+    defaults,
+    ...(rules?.length ? { rules } : {}),
+  };
+}
+
+export function createProjectManifestRegistrations(
+  project: ProjectScopeSnapshot,
+  lifecycle: VfsLifecycle,
+  mountPoint = "/",
+  namePrefix = "project-manifest",
+): VfsSourceRegistration[] {
+  const normalizedMountPoint = normalizeMountPoint(mountPoint);
+  const registrations: VfsSourceRegistration[] = [
+    createProjectManifestRegistration(project, lifecycle, normalizedMountPoint, namePrefix),
+  ];
+
+  for (const child of project.children) {
+    registrations.push(
+      ...createProjectManifestRegistrations(
+        child,
+        lifecycle,
+        joinMountedPath(normalizedMountPoint, "projects", child.name),
+        namePrefix,
+      ),
+    );
+  }
+
+  return registrations;
+}
+
+export function compileProjectPermissionRules(
+  project: ProjectScopeSnapshot,
+  mountPoint = "/",
+): VfsPermissionRule[] {
+  const normalizedMountPoint = normalizeMountPoint(mountPoint);
+  const rules = compilePermissionConfig(project.effectivePermissions, normalizedMountPoint);
+
+  for (const child of project.children) {
+    rules.push(
+      ...compileProjectPermissionRules(
+        child,
+        joinMountedPath(normalizedMountPoint, "projects", child.name),
+      ),
+    );
+  }
+
+  return rules;
+}
+
+function createProjectManifestRegistration(
+  project: ProjectScopeSnapshot,
+  lifecycle: VfsLifecycle,
+  mountPoint: string,
+  namePrefix: string,
+): VfsSourceRegistration {
+  const projection = createProjection(project, mountPoint);
+
+  return {
+    name: toRegistrationName(namePrefix, mountPoint),
+    mountPoint,
+    sourceType: "component-source",
+    lifecycle,
+    metadata: {
+      description: `Project manifest projection for ${project.name}`,
+      virtual: true,
+      readOnly: true,
+      projectName: project.name,
+      projectRoot: project.projectRoot,
+    },
+    fileSchema: {},
+    handlers: {
+      read: async (filePath: string) => {
+        const normalized = normalizeRelativePath(filePath);
+        if (normalized !== "_project.json") {
+          throw new Error(`Unknown project file: ${filePath}`);
+        }
+        return {
+          content: JSON.stringify(projection, null, 2),
+          mimeType: "application/json",
+        };
+      },
+      list: async (dirPath: string) => {
+        const normalized = normalizeRelativePath(dirPath);
+        if (normalized === "") {
+          return listProjectionEntries(projection);
+        }
+        if (normalized === "projects") {
+          return projection.children.map((child) => ({
+            name: child.name,
+            path: child.mountPoint,
+            type: "directory" as const,
+          }));
+        }
+        throw new Error(`Unknown project directory: ${dirPath}`);
+      },
+      stat: async (filePath: string) => {
+        const normalized = normalizeRelativePath(filePath);
+        if (normalized === "") {
+          return directoryStat();
+        }
+        if (normalized === "_project.json") {
+          return fileStat();
+        }
+        if (projectionDirectoryNames(projection).has(normalized)) {
+          return directoryStat();
+        }
+        throw new Error(`Unknown project file: ${filePath}`);
+      },
+    },
+  };
+}
+
+function createProjection(
+  project: ProjectScopeSnapshot,
+  mountPoint: string,
+): ProjectManifestProjection {
+  return {
+    name: project.name,
+    projectRoot: project.projectRoot,
+    manifestPath: project.manifestPath,
+    mountPoint,
+    manifest: project.manifest,
+    effectivePermissions: project.effectivePermissions,
+    children: project.children.map((child) => ({
+      name: child.name,
+      mountPoint: joinMountedPath(mountPoint, "projects", child.name),
+      projectRoot: child.projectRoot,
+      manifestPath: child.manifestPath,
+    })),
+  };
+}
+
+function listProjectionEntries(
+  projection: ProjectManifestProjection,
+): VfsEntry[] {
+  const entries: VfsEntry[] = [{
+    name: "_project.json",
+    path: absoluteEntryPath(projection.mountPoint, "_project.json"),
+    type: "file",
+  }];
+
+  for (const mount of projection.manifest.mounts) {
+    const topLevel = normalizeRelativePath(mount.path).split("/")[0];
+    if (!topLevel) {
+      continue;
+    }
+    entries.push({
+      name: topLevel,
+      path: absoluteEntryPath(projection.mountPoint, topLevel),
+      type: "directory",
+    });
+  }
+
+  if (projection.children.length > 0) {
+    entries.push({
+      name: "projects",
+      path: absoluteEntryPath(projection.mountPoint, "projects"),
+      type: "directory",
+    });
+  }
+
+  return dedupeEntries(entries);
+}
+
+function projectionDirectoryNames(
+  projection: ProjectManifestProjection,
+): Set<string> {
+  const names = new Set<string>();
+  for (const mount of projection.manifest.mounts) {
+    const topLevel = normalizeRelativePath(mount.path).split("/")[0];
+    if (topLevel) {
+      names.add(topLevel);
+    }
+  }
+  if (projection.children.length > 0) {
+    names.add("projects");
+  }
+  return names;
+}
+
+function compilePermissionConfig(
+  permissionConfig: PermissionConfig,
+  mountPoint: string,
+): VfsPermissionRule[] {
+  const pattern = toProjectPattern(mountPoint);
+  const rules = compilePermissionSet(permissionConfig.defaults, {
+    pathPattern: pattern,
+    principal: { type: "any" },
+    allowPriority: 500,
+    denyPriority: 550,
+    includeUndefined: true,
+  });
+
+  for (const rule of permissionConfig.rules ?? []) {
+    rules.push(
+      ...compilePermissionSet(rule, {
+        pathPattern: toScopedPattern(mountPoint, rule.path),
+        principal: rule.agent === "*" ? { type: "any" } : { type: "agent", name: rule.agent },
+        allowPriority: 600,
+        denyPriority: 650,
+        includeUndefined: false,
+      }),
+    );
+  }
+
+  return rules;
+}
+
+function compilePermissionSet(
+  permissionSet: PermissionSet,
+  options: {
+    pathPattern: string;
+    principal: VfsPermissionRule["principal"];
+    allowPriority: number;
+    denyPriority: number;
+    includeUndefined: boolean;
+  },
+): VfsPermissionRule[] {
+  const rules: VfsPermissionRule[] = [];
+  const entries: Array<[keyof PermissionSet, VfsCapabilityId[]]> = [
+    ["read", READ_ACTIONS],
+    ["write", WRITE_ACTIONS],
+    ["watch", WATCH_ACTIONS],
+    ["stream", STREAM_ACTIONS],
+  ];
+
+  for (const [field, actions] of entries) {
+    const value = permissionSet[field];
+    if (value === undefined && !options.includeUndefined) {
+      continue;
+    }
+
+    rules.push({
+      pathPattern: options.pathPattern,
+      principal: options.principal,
+      actions,
+      effect: value === false ? "deny" : "allow",
+      priority: value === false ? options.denyPriority : options.allowPriority,
+    });
+  }
+
+  return rules;
+}
+
+function narrowPermissionSet(
+  base: PermissionSet,
+  local: PermissionSet | undefined,
+): PermissionSet {
+  return {
+    read: narrowPermissionFlag(base.read, local?.read),
+    write: narrowPermissionFlag(base.write, local?.write),
+    watch: narrowPermissionFlag(base.watch, local?.watch),
+    stream: narrowPermissionFlag(base.stream, local?.stream),
+  };
+}
+
+function narrowPermissionFlag(
+  base: boolean | undefined,
+  local: boolean | undefined,
+): boolean {
+  if (base === false) {
+    return false;
+  }
+  if (local === undefined) {
+    return base ?? true;
+  }
+  return local;
+}
+
+function toProjectPattern(mountPoint: string): string {
+  return mountPoint === "/" ? "/**" : `${mountPoint}/**`;
+}
+
+function toScopedPattern(mountPoint: string, projectPath: string): string {
+  const scoped = joinMountedPath(mountPoint, projectPath);
+  return scoped.endsWith("/**") || scoped.endsWith("/*") ? scoped : `${scoped.replace(/\/+$/, "")}/**`;
+}
+
+function toRegistrationName(namePrefix: string, mountPoint: string): string {
+  const suffix = mountPoint === "/"
+    ? "root"
+    : mountPoint.split("/").filter(Boolean).join("-");
+  return `${namePrefix}-${suffix}`;
+}
+
+function joinMountedPath(base: string, ...parts: string[]): string {
+  const allParts = [
+    ...base.split("/").filter(Boolean),
+    ...parts.flatMap((part) => part.split("/").filter(Boolean)),
+  ];
+  return allParts.length === 0 ? "/" : `/${allParts.join("/")}`;
+}
+
+function normalizeMountPoint(mountPoint: string): string {
+  const normalized = `/${mountPoint}`.replace(/\/+/g, "/");
+  return normalized === "/" ? normalized : normalized.replace(/\/+$/, "");
+}
+
+function normalizeRelativePath(filePath: string): string {
+  if (!filePath || filePath === ".") {
+    return "";
+  }
+  return filePath.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function absoluteEntryPath(mountPoint: string, entry: string): string {
+  return joinMountedPath(mountPoint, entry);
+}
+
+function dedupeEntries(entries: VfsEntry[]): VfsEntry[] {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    if (seen.has(entry.path)) {
+      return false;
+    }
+    seen.add(entry.path);
+    return true;
+  });
+}
+
+function directoryStat(): VfsStatResult {
+  return {
+    type: "directory",
+    size: 0,
+    mtime: new Date().toISOString(),
+  };
+}
+
+function fileStat(): VfsStatResult {
+  return {
+    type: "file",
+    size: 0,
+    mtime: new Date().toISOString(),
+    mimeType: "application/json",
+  };
+}

--- a/packages/mcp-server/src/context-backend.test.ts
+++ b/packages/mcp-server/src/context-backend.test.ts
@@ -84,7 +84,7 @@ describe("createStandaloneContext", () => {
 
     const mounts = await backend.list("/");
     expect(mounts.map((entry) => entry.path)).toEqual(
-      expect.arrayContaining(["/project", "/workspace", "/skills", "/daemon", "/config"]),
+      expect.arrayContaining(["/_project.json", "/project", "/workspace", "/skills", "/daemon", "/config"]),
     );
 
     const context = JSON.parse((await backend.read("/project/context.json")).content) as {
@@ -97,6 +97,14 @@ describe("createStandaloneContext", () => {
     const skillCatalog = await backend.list("/skills");
     expect(skillCatalog.map((entry) => entry.path)).toEqual(
       expect.arrayContaining(["_catalog.json", "local-skill"]),
+    );
+
+    const manifest = JSON.parse((await backend.read("/_project.json")).content) as {
+      manifest: { name: string; mounts: Array<{ path: string }> };
+    };
+    expect(manifest.manifest.name).toBe(projectDir.split(/[/\\\\]/).pop());
+    expect(manifest.manifest.mounts.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(["/workspace", "/skills"]),
     );
   });
 
@@ -237,6 +245,90 @@ describe("createStandaloneContext", () => {
     ]);
     expect(context.available.skills).toEqual(expect.arrayContaining(["reader"]));
     expect(context.available.prompts).toEqual(expect.arrayContaining(["bootstrap"]));
+  });
+
+  it("mounts child projects under /projects with narrowed effective permissions", async () => {
+    const projectDir = await makeTempProject();
+    const childDir = join(projectDir, "packages", "child-project");
+
+    await mkdir(join(projectDir, "configs", "skills"), { recursive: true });
+    await mkdir(join(childDir, "configs", "skills"), { recursive: true });
+    await writeFile(
+      join(projectDir, "configs", "skills", "root-skill.json"),
+      JSON.stringify({
+        name: "root-skill",
+        description: "Root project skill",
+        content: "Available to the root project.",
+      }, null, 2),
+      "utf-8",
+    );
+    await writeFile(
+      join(childDir, "configs", "skills", "child-skill.json"),
+      JSON.stringify({
+        name: "child-skill",
+        description: "Child project skill",
+        content: "Available to the child project.",
+      }, null, 2),
+      "utf-8",
+    );
+    await writeFile(
+      join(childDir, "actant.project.json"),
+      JSON.stringify({
+        version: 1,
+        name: "child-project",
+        permissions: {
+          defaults: {
+            read: true,
+            write: false,
+            watch: false,
+            stream: false,
+          },
+        },
+      }, null, 2),
+      "utf-8",
+    );
+    await writeFile(
+      join(projectDir, "actant.project.json"),
+      JSON.stringify({
+        version: 1,
+        name: "root-project",
+        permissions: {
+          defaults: {
+            read: true,
+            write: true,
+            watch: true,
+            stream: true,
+          },
+        },
+        children: [
+          {
+            name: "child",
+            manifest: "./packages/child-project/actant.project.json",
+          },
+        ],
+      }, null, 2),
+      "utf-8",
+    );
+
+    const backend = await createStandaloneContext(projectDir);
+    const mounts = await backend.list("/");
+    expect(mounts.map((entry) => entry.path)).toEqual(expect.arrayContaining(["/projects/child"]));
+
+    const childMounts = await backend.list("/projects/child");
+    expect(childMounts.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(["/projects/child/_project.json", "/projects/child/project", "/projects/child/workspace", "/projects/child/skills"]),
+    );
+
+    const childManifest = JSON.parse((await backend.read("/projects/child/_project.json")).content) as {
+      name: string;
+      effectivePermissions: { defaults: { write: boolean; watch: boolean } };
+    };
+    expect(childManifest.name).toBe("child");
+    expect(childManifest.effectivePermissions.defaults.write).toBe(false);
+    expect(childManifest.effectivePermissions.defaults.watch).toBe(false);
+
+    const childSkills = await backend.list("/projects/child/skills");
+    expect(childSkills.map((entry) => entry.path)).toEqual(expect.arrayContaining(["child-skill"]));
   });
 
   it("dedupes missing entrypoint warnings when knowledge and readFirst overlap", async () => {

--- a/packages/mcp-server/src/context-backend.ts
+++ b/packages/mcp-server/src/context-backend.ts
@@ -189,14 +189,29 @@ export async function createStandaloneContext(projectDir?: string): Promise<Stan
       const resolved = registry.resolve(path);
       if (!resolved) {
         const childMounts = registry.listChildMounts(path);
-        return childMounts.map((s) => ({
+        return childMounts.map((s: { mountPoint: string; name: string }) => ({
           name: s.mountPoint.split("/").pop() ?? s.name,
           path: s.mountPoint,
           type: "directory" as const,
         }));
       }
       const handler = requireHandler(resolved.source.handlers.list, "list", path);
-      return handler(resolved.relativePath, { recursive, long });
+      const entries = await handler(resolved.relativePath, { recursive, long });
+      if (resolved.relativePath !== "") {
+        return entries;
+      }
+
+      const childMounts = registry.listChildMounts(path);
+      const projectedMounts = childMounts.map((s: { mountPoint: string; name: string }) => ({
+        name: s.mountPoint.split("/").pop() ?? s.name,
+        path: s.mountPoint,
+        type: "directory" as const,
+      }));
+      const deduped = new Map<string, (typeof entries)[number]>();
+      for (const entry of [...entries, ...projectedMounts]) {
+        deduped.set(entry.path, entry);
+      }
+      return [...deduped.values()];
     },
     async describe(path) {
       const desc = registry.describe(path);
@@ -231,7 +246,9 @@ export async function createStandaloneContext(projectDir?: string): Promise<Stan
 function mapConnectedPath(path?: string): string {
   const raw = path ?? "/";
   const aliases: Array<[string, string]> = [
+    ["/_project.json", "/hub/_project.json"],
     ["/project", "/hub/project"],
+    ["/projects", "/hub/projects"],
     ["/workspace", "/hub/workspace"],
     ["/config", "/hub/config"],
     ["/skills", "/hub/skills"],

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -94,6 +94,12 @@ export type {
 } from "./source.types";
 export type {
   ProjectSourceEntry,
+  MountDeclaration,
+  PermissionSet,
+  PermissionRule,
+  PermissionConfig,
+  ChildProjectRef,
+  ProjectManifest,
   ActantProjectEntrypoints,
   ActantProjectConfig,
 } from "./project.types";

--- a/packages/shared/src/types/project.types.ts
+++ b/packages/shared/src/types/project.types.ts
@@ -5,6 +5,41 @@ export interface ProjectSourceEntry {
   config: SourceConfig;
 }
 
+export interface MountDeclaration {
+  source: string;
+  path: string;
+  config?: Record<string, unknown>;
+}
+
+export interface PermissionSet {
+  read?: boolean;
+  write?: boolean;
+  watch?: boolean;
+  stream?: boolean;
+}
+
+export interface PermissionRule extends PermissionSet {
+  agent: string;
+  path: string;
+}
+
+export interface PermissionConfig {
+  defaults: PermissionSet;
+  rules?: PermissionRule[];
+}
+
+export interface ChildProjectRef {
+  name: string;
+  manifest: string;
+}
+
+export interface ProjectManifest {
+  name: string;
+  mounts: MountDeclaration[];
+  permissions?: PermissionConfig;
+  children?: ChildProjectRef[];
+}
+
 export interface ActantProjectEntrypoints {
   /**
    * Ordered project-root-relative files a backend should inspect after
@@ -24,8 +59,9 @@ export interface ActantProjectEntrypoints {
  * - selects the configs directory for local domain components
  * - declares extra component sources visible to the current project
  * - points backends at the project knowledge files they should read first
+ * - now also carries M3 project-boundary permissions + child-project refs
  */
-export interface ActantProjectConfig {
+export interface ActantProjectConfig extends Partial<ProjectManifest> {
   version?: 1;
   name?: string;
   description?: string;

--- a/packages/vfs/src/__tests__/vfs-registry.test.ts
+++ b/packages/vfs/src/__tests__/vfs-registry.test.ts
@@ -62,8 +62,11 @@ describe("VfsRegistry", () => {
       registry.mount(createSource("mem-a", "/memory/agent-a"));
       const result = registry.resolve("/memory/agent-a");
       expect(result).not.toBeNull();
-      expect(result!.source.name).toBe("mem-a");
-      expect(result!.relativePath).toBe("");
+      if (!result) {
+        throw new Error("Expected mount resolution for /memory/agent-a");
+      }
+      expect(result.source.name).toBe("mem-a");
+      expect(result.relativePath).toBe("");
     });
 
     it("resolves a file within a mount", () => {
@@ -83,6 +86,36 @@ describe("VfsRegistry", () => {
       registry.mount(createSource("proc-a", "/proc/agent-a"));
       const result = registry.resolve("/proc/agent-a/stdout");
       expect(result!.source.name).toBe("proc-a");
+    });
+
+    it("resolves files beneath a root mount", () => {
+      registry.mount(createSource("root", "/"));
+      const result = registry.resolve("/_project.json");
+      expect(result).not.toBeNull();
+      if (!result) {
+        throw new Error("Expected root mount resolution for /_project.json");
+      }
+      expect(result.source.name).toBe("root");
+      expect(result.relativePath).toBe("_project.json");
+    });
+  });
+
+  describe("listChildMounts", () => {
+    it("prefers the shallowest descendant per segment when listing root mounts", () => {
+      registry.mount(createSource("root", "/"));
+      registry.mount(createSource("child-scope", "/projects/child"));
+      registry.mount(createSource("child-workspace", "/projects/child/workspace"));
+
+      const mounts = registry.listChildMounts("/");
+      expect(mounts.map((mount) => mount.mountPoint)).toEqual(["/projects/child"]);
+    });
+
+    it("prefers the direct child project scope over nested mounts", () => {
+      registry.mount(createSource("child-scope", "/projects/child"));
+      registry.mount(createSource("child-workspace", "/projects/child/workspace"));
+
+      const mounts = registry.listChildMounts("/projects");
+      expect(mounts.map((mount) => mount.mountPoint)).toEqual(["/projects/child"]);
     });
   });
 

--- a/packages/vfs/src/mount/direct-mount-table.ts
+++ b/packages/vfs/src/mount/direct-mount-table.ts
@@ -68,8 +68,7 @@ export class DirectMountTable {
   listChildMounts(dirPath: string): VfsSourceRegistration[] {
     const normalized = normalizeVfsPath(dirPath);
     const prefix = normalized === "/" ? "/" : `${normalized}/`;
-    const children: VfsSourceRegistration[] = [];
-    const seen = new Set<string>();
+    const children = new Map<string, MountRecord>();
 
     for (const { mountPoint, source } of this.mounts) {
       if (normalized !== "/" && !mountPoint.startsWith(prefix)) {
@@ -83,26 +82,33 @@ export class DirectMountTable {
         ? mountPoint.slice(1)
         : mountPoint.slice(prefix.length);
       const firstSegment = remainder.split("/")[0];
-      if (!firstSegment || seen.has(firstSegment)) {
+      if (!firstSegment) {
         continue;
       }
 
-      seen.add(firstSegment);
-      children.push(source);
+      const existing = children.get(firstSegment);
+      if (!existing || mountPoint.length < existing.mountPoint.length) {
+        children.set(firstSegment, { mountPoint, source });
+      }
     }
 
-    return children;
+    return Array.from(children.values(), ({ source }) => source);
   }
 
   resolve(path: string): VfsResolveResult | null {
     const normalized = normalizeVfsPath(path);
 
     for (const { mountPoint, source } of this.mounts) {
-      if (normalized !== mountPoint && !normalized.startsWith(`${mountPoint}/`)) {
+      const matchesMount = mountPoint === "/"
+        ? normalized.startsWith("/")
+        : normalized === mountPoint || normalized.startsWith(`${mountPoint}/`);
+      if (!matchesMount) {
         continue;
       }
 
-      const relativePath = normalized === mountPoint ? "" : normalized.slice(mountPoint.length + 1);
+      const relativePath = mountPoint === "/"
+        ? (normalized === "/" ? "" : normalized.slice(1))
+        : (normalized === mountPoint ? "" : normalized.slice(mountPoint.length + 1));
       const fileSchema = resolveFileSchema(relativePath, source.fileSchema);
       return { source, relativePath, fileSchema };
     }


### PR DESCRIPTION
## Summary
- rebuild ContextFS orchestration around ProjectManifest and project-scoped permission compilation
- expose root and child project projections through /_project.json and /projects/* across API, MCP, CLI, and VFS
- add regression coverage for child mount projection, daemon path forwarding, and root mount resolution

## Verification
- pnpm lint
- pnpm type-check
- pnpm test