### PR TITLE
feat(contextfs): implement M5 control node & stream node execution model

### DIFF
--- a/packages/vfs/src/__tests__/m5-control-stream-e2e.test.ts
+++ b/packages/vfs/src/__tests__/m5-control-stream-e2e.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { AgentInstanceMeta, VfsStreamChunk, VfsWriteResult } from "@actant/shared";
+import { VfsKernel } from "../core/vfs-kernel";
+import {
+  createAgentRuntimeSource,
+  createMcpRuntimeSource,
+  type AgentControlRequest,
+  type AgentRuntimeSourceProvider,
+  type McpRuntimeSourceProvider,
+} from "../sources";
+
+function createAgentMeta(name: string): AgentInstanceMeta {
+  return {
+    id: `${name}-id`,
+    name,
+    templateName: "test-template",
+    templateVersion: "1.0.0",
+    backendType: "claude-code",
+    interactionModes: ["run"],
+    status: "running",
+    launchMode: "direct",
+    workspacePolicy: "persistent",
+    processOwnership: "managed",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    archetype: "repo",
+    autoStart: false,
+  };
+}
+
+async function collectStream(iterable: AsyncIterable<VfsStreamChunk>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of iterable) {
+    chunks.push(chunk.content);
+  }
+  return chunks;
+}
+
+describe("M5 control + stream execution model", () => {
+  it("writes to control/request.json to trigger agent execution and consumes stable stdout", async () => {
+    const calls: AgentControlRequest[] = [];
+    const provider: AgentRuntimeSourceProvider = {
+      listAgents: () => [createAgentMeta("worker")],
+      getAgent: (name) => (name === "worker" ? createAgentMeta(name) : undefined),
+      writeControl: async (_name, _controlPath, content): Promise<VfsWriteResult> => {
+        calls.push(JSON.parse(content) as AgentControlRequest);
+        return { bytesWritten: Buffer.byteLength(content), created: false };
+      },
+      stream: async function* (_name, stream) {
+        expect(stream).toBe("stdout");
+        yield { content: "booting\n", timestamp: 1 };
+        yield { content: "done\n", timestamp: 2 };
+      },
+    };
+
+    const kernel = new VfsKernel();
+    kernel.mount(createAgentRuntimeSource(provider, "/agents", { type: "manual" }));
+
+    await kernel.write(
+      "/agents/worker/control/request.json",
+      JSON.stringify({ prompt: "run diagnostics", sessionId: "session-1" }),
+    );
+
+    const chunks = await collectStream(await kernel.stream("/agents/worker/streams/stdout"));
+    expect(calls).toEqual([
+      {
+        prompt: "run diagnostics",
+        sessionId: "session-1",
+      },
+    ]);
+    expect(chunks).toEqual(["booting\n", "done\n"]);
+  });
+
+  it("provides a stable synthetic MCP runtime events stream without a separate execution system", async () => {
+    const provider: McpRuntimeSourceProvider = {
+      listRuntimes: () => [
+        {
+          name: "local-runtime",
+          status: "inactive",
+          command: "npx",
+          args: ["@modelcontextprotocol/server"],
+          transport: "stdio",
+        },
+      ],
+      getRuntime: (name) => (
+        name === "local-runtime"
+          ? {
+            name,
+            status: "inactive",
+            command: "npx",
+            args: ["@modelcontextprotocol/server"],
+            transport: "stdio",
+          }
+          : undefined
+      ),
+    };
+
+    const kernel = new VfsKernel();
+    kernel.mount(createMcpRuntimeSource(provider, "/mcp/runtime", { type: "manual" }));
+
+    const chunks = await collectStream(await kernel.stream("/mcp/runtime/local-runtime/streams/events"));
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain("\"type\": \"snapshot\"");
+    expect(chunks[0]).toContain("\"local-runtime\"");
+  });
+
+  it("uses explicit error semantics for invalid control requests and missing streams", async () => {
+    const provider: AgentRuntimeSourceProvider = {
+      listAgents: () => [createAgentMeta("worker")],
+      getAgent: (name) => (name === "worker" ? createAgentMeta(name) : undefined),
+      writeControl: async () => ({ bytesWritten: 0, created: false }),
+    };
+
+    const kernel = new VfsKernel();
+    kernel.mount(createAgentRuntimeSource(provider, "/agents", { type: "manual" }));
+
+    await expect(
+      kernel.write("/agents/worker/control/request.json", JSON.stringify({ prompt: "" })),
+    ).rejects.toThrow('Invalid control request for agent "worker": "prompt" must be a non-empty string');
+
+    await expect(
+      kernel.stream("/agents/worker/streams/events"),
+    ).rejects.toThrow("Stream not found");
+  });
+});

--- a/packages/vfs/src/sources/agent-runtime-source.ts
+++ b/packages/vfs/src/sources/agent-runtime-source.ts
@@ -1,0 +1,412 @@
+import type {
+  AgentInstanceMeta,
+  VfsFileContent,
+  VfsEntry,
+  VfsFileSchemaMap,
+  VfsHandlerMap,
+  VfsLifecycle,
+  VfsListOptions,
+  VfsSourceRegistration,
+  VfsStatResult,
+  VfsStreamChunk,
+  VfsWatchEvent,
+  VfsWatchOptions,
+  VfsWriteResult,
+} from "@actant/shared";
+
+export interface AgentControlRequest {
+  prompt: string;
+  sessionId?: string;
+}
+
+export interface AgentRuntimeWatchEvent {
+  type: "create" | "modify" | "delete";
+  agentName?: string;
+  timestamp?: number;
+}
+
+export interface AgentRuntimeSourceProvider {
+  listAgents(): AgentInstanceMeta[];
+  getAgent(name: string): AgentInstanceMeta | undefined;
+  readStream?(
+    name: string,
+    stream: "stdout" | "stderr",
+  ): Promise<VfsFileContent> | VfsFileContent;
+  stream?(
+    name: string,
+    stream: "stdout" | "stderr",
+  ): Promise<AsyncIterable<VfsStreamChunk>> | AsyncIterable<VfsStreamChunk>;
+  writeControl?(
+    name: string,
+    controlPath: "request.json",
+    content: string,
+  ): Promise<VfsWriteResult>;
+  subscribe?(listener: (event: AgentRuntimeWatchEvent) => void): () => void;
+}
+
+const AGENT_RUNTIME_FILE_SCHEMA: VfsFileSchemaMap = {
+  "_catalog.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "status.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "streams": {
+    type: "directory",
+    capabilities: ["list", "stat"],
+  },
+  "stdout": {
+    type: "stream",
+    mimeType: "text/plain",
+    capabilities: ["read", "stream", "stat"],
+  },
+  "stderr": {
+    type: "stream",
+    mimeType: "text/plain",
+    capabilities: ["read", "stream", "stat"],
+  },
+  "control": {
+    type: "directory",
+    capabilities: ["list", "stat"],
+  },
+  "request.json": {
+    type: "control",
+    mimeType: "application/json",
+    capabilities: ["read", "write", "stat"],
+  },
+};
+
+type ParsedAgentPath =
+  | { kind: "root" }
+  | { kind: "catalog" }
+  | { kind: "agent"; agentName: string }
+  | { kind: "status"; agentName: string }
+  | { kind: "streams"; agentName: string }
+  | { kind: "stream"; agentName: string; streamName: string }
+  | { kind: "control"; agentName: string }
+  | { kind: "request"; agentName: string };
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function parseAgentPath(filePath: string): ParsedAgentPath {
+  const normalized = normalizePath(filePath);
+  if (!normalized) {
+    return { kind: "root" };
+  }
+  if (normalized === "_catalog.json") {
+    return { kind: "catalog" };
+  }
+
+  const parts = normalized.split("/");
+  const agentName = parts[0];
+  if (!agentName) {
+    throw new Error(`Agent path not found: ${filePath}`);
+  }
+
+  if (parts.length === 1) {
+    return { kind: "agent", agentName };
+  }
+  if (parts.length === 2 && parts[1] === "status.json") {
+    return { kind: "status", agentName };
+  }
+  if (parts.length === 2 && parts[1] === "streams") {
+    return { kind: "streams", agentName };
+  }
+  if (parts.length === 3 && parts[1] === "streams") {
+    return { kind: "stream", agentName, streamName: parts[2] ?? "" };
+  }
+  if (parts.length === 2 && parts[1] === "control") {
+    return { kind: "control", agentName };
+  }
+  if (parts.length === 3 && parts[1] === "control" && parts[2] === "request.json") {
+    return { kind: "request", agentName };
+  }
+
+  throw new Error(`Agent path not found: ${filePath}`);
+}
+
+function requireAgent(
+  provider: AgentRuntimeSourceProvider,
+  agentName: string,
+): AgentInstanceMeta {
+  const agent = provider.getAgent(agentName);
+  if (!agent) {
+    throw new Error(`Agent not found: ${agentName}`);
+  }
+  return agent;
+}
+
+function parseAgentControlRequest(agentName: string, content: string): AgentControlRequest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(
+      `Invalid control request for agent "${agentName}": ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  if (parsed == null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`Invalid control request for agent "${agentName}": payload must be a JSON object`);
+  }
+
+  const request = parsed as Record<string, unknown>;
+  if (typeof request.prompt !== "string" || request.prompt.trim().length === 0) {
+    throw new Error(`Invalid control request for agent "${agentName}": "prompt" must be a non-empty string`);
+  }
+
+  const sessionId = request.sessionId;
+  if (sessionId != null && typeof sessionId !== "string") {
+    throw new Error(`Invalid control request for agent "${agentName}": "sessionId" must be a string`);
+  }
+
+  return {
+    prompt: request.prompt,
+    sessionId: typeof sessionId === "string" ? sessionId : undefined,
+  };
+}
+
+function toCatalogEntry(agent: AgentInstanceMeta): Record<string, unknown> {
+  return {
+    name: agent.name,
+    templateName: agent.templateName,
+    status: agent.status,
+    archetype: agent.archetype,
+    startedAt: agent.startedAt,
+  };
+}
+
+function matchesWatchTarget(requestedPath: string, eventPath: string): boolean {
+  const normalizedRequested = normalizePath(requestedPath);
+  if (!normalizedRequested) {
+    return true;
+  }
+  return eventPath === normalizedRequested || eventPath.startsWith(`${normalizedRequested}/`);
+}
+
+function eventPathsForAgentEvent(event: AgentRuntimeWatchEvent): string[] {
+  const agentName = event.agentName;
+  if (!agentName) {
+    return ["status.json"];
+  }
+  if (event.type === "create" || event.type === "delete") {
+    return [agentName, `${agentName}/status.json`];
+  }
+  return [`${agentName}/status.json`];
+}
+
+async function* oneShotStream(content: VfsFileContent): AsyncGenerator<VfsStreamChunk> {
+  if (content.content.length === 0) {
+    return;
+  }
+  yield {
+    content: content.content,
+    mimeType: content.mimeType,
+    encoding: content.encoding,
+    timestamp: Date.now(),
+  };
+}
+
+export function createAgentRuntimeSource(
+  provider: AgentRuntimeSourceProvider,
+  mountPoint: string,
+  lifecycle: VfsLifecycle,
+): VfsSourceRegistration {
+  const handlers: VfsHandlerMap = {};
+
+  handlers.read = async (filePath: string): Promise<VfsFileContent> => {
+    const parsed = parseAgentPath(filePath);
+
+    if (parsed.kind === "catalog") {
+      return {
+        content: JSON.stringify(provider.listAgents().map(toCatalogEntry), null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    if (parsed.kind === "status") {
+      return {
+        content: JSON.stringify(requireAgent(provider, parsed.agentName), null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    if (parsed.kind === "stream") {
+      requireAgent(provider, parsed.agentName);
+      const streamName = requireAgentStream(parsed.streamName);
+      if (provider.readStream) {
+        return provider.readStream(parsed.agentName, streamName);
+      }
+      return { content: "", mimeType: "text/plain" };
+    }
+
+    if (parsed.kind === "request") {
+      requireAgent(provider, parsed.agentName);
+      return {
+        content: "{}",
+        mimeType: "application/json",
+      };
+    }
+
+    throw new Error(`Agent path not readable: ${filePath}`);
+  };
+
+  handlers.write = async (filePath: string, content: string): Promise<VfsWriteResult> => {
+    const parsed = parseAgentPath(filePath);
+    if (parsed.kind !== "request") {
+      throw new Error(`Agent path is not writable: ${filePath}`);
+    }
+
+    requireAgent(provider, parsed.agentName);
+    parseAgentControlRequest(parsed.agentName, content);
+
+    if (!provider.writeControl) {
+      throw new Error(`Capability "write" not supported for path "${parsed.agentName}/control/request.json"`);
+    }
+
+    return provider.writeControl(parsed.agentName, "request.json", content);
+  };
+
+  handlers.list = async (dirPath: string, _opts?: VfsListOptions): Promise<VfsEntry[]> => {
+    const parsed = parseAgentPath(dirPath);
+
+    if (parsed.kind === "root") {
+      const entries: VfsEntry[] = provider.listAgents().map((agent) => ({
+        name: agent.name,
+        path: agent.name,
+        type: "directory" as const,
+      }));
+      entries.unshift({
+        name: "_catalog.json",
+        path: "_catalog.json",
+        type: "file",
+      });
+      return entries;
+    }
+
+    if (parsed.kind === "agent") {
+      requireAgent(provider, parsed.agentName);
+      return [
+        { name: "status.json", path: `${parsed.agentName}/status.json`, type: "file" },
+        { name: "streams", path: `${parsed.agentName}/streams`, type: "directory" },
+        { name: "control", path: `${parsed.agentName}/control`, type: "directory" },
+      ];
+    }
+
+    if (parsed.kind === "streams") {
+      requireAgent(provider, parsed.agentName);
+      return [
+        { name: "stdout", path: `${parsed.agentName}/streams/stdout`, type: "file" },
+        { name: "stderr", path: `${parsed.agentName}/streams/stderr`, type: "file" },
+      ];
+    }
+
+    if (parsed.kind === "control") {
+      requireAgent(provider, parsed.agentName);
+      return [
+        { name: "request.json", path: `${parsed.agentName}/control/request.json`, type: "file" },
+      ];
+    }
+
+    throw new Error(`Agent path not listable: ${dirPath}`);
+  };
+
+  handlers.stat = async (filePath: string): Promise<VfsStatResult> => {
+    const parsed = parseAgentPath(filePath);
+    if (parsed.kind === "root" || parsed.kind === "agent" || parsed.kind === "streams" || parsed.kind === "control") {
+      return { size: 0, type: "directory", mtime: new Date().toISOString() };
+    }
+    if (parsed.kind === "catalog") {
+      return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+    }
+    if (parsed.kind === "status") {
+      const agent = requireAgent(provider, parsed.agentName);
+      return {
+        size: Buffer.byteLength(JSON.stringify(agent)),
+        type: "file",
+        mtime: agent.updatedAt,
+        mimeType: "application/json",
+      };
+    }
+
+    requireAgent(provider, parsed.agentName);
+    if (parsed.kind === "stream") {
+      requireAgentStream(parsed.streamName);
+    }
+    return {
+      size: 0,
+      type: "file",
+      mtime: new Date().toISOString(),
+      mimeType: parsed.kind === "stream" ? "text/plain" : "application/json",
+    };
+  };
+
+  handlers.watch = (
+    pattern: string,
+    callback: (event: VfsWatchEvent) => void,
+    opts?: VfsWatchOptions,
+  ) => {
+    if (!provider.subscribe) {
+      return () => undefined;
+    }
+
+    return provider.subscribe((event) => {
+      if (opts?.events && !opts.events.includes(event.type)) {
+        return;
+      }
+      for (const eventPath of eventPathsForAgentEvent(event)) {
+        if (!matchesWatchTarget(pattern, eventPath)) {
+          continue;
+        }
+        callback({
+          type: event.type,
+          path: eventPath,
+          timestamp: event.timestamp ?? Date.now(),
+        });
+      }
+    });
+  };
+
+  handlers.stream = async (filePath: string): Promise<AsyncIterable<VfsStreamChunk>> => {
+    const parsed = parseAgentPath(filePath);
+    if (parsed.kind !== "stream") {
+      throw new Error(`Stream not found: ${filePath}`);
+    }
+
+    requireAgent(provider, parsed.agentName);
+    const streamName = requireAgentStream(parsed.streamName);
+
+    if (provider.stream) {
+      return provider.stream(parsed.agentName, streamName);
+    }
+    if (provider.readStream) {
+      const content = await provider.readStream(parsed.agentName, streamName);
+      return oneShotStream(content);
+    }
+
+    return oneShotStream({ content: "", mimeType: "text/plain" });
+  };
+
+  return {
+    name: "agents",
+    mountPoint,
+    sourceType: "component-source",
+    lifecycle,
+    metadata: { description: "Built-in agent runtime source", virtual: true },
+    fileSchema: AGENT_RUNTIME_FILE_SCHEMA,
+    handlers,
+  };
+}
+function requireAgentStream(streamName: string): "stdout" | "stderr" {
+  if (streamName !== "stdout" && streamName !== "stderr") {
+    throw new Error(`Stream not found: ${streamName}`);
+  }
+  return streamName;
+}

--- a/packages/vfs/src/sources/mcp-config-source.ts
+++ b/packages/vfs/src/sources/mcp-config-source.ts
@@ -1,0 +1,187 @@
+import type {
+  VfsSourceRegistration,
+  VfsFileSchemaMap,
+  VfsLifecycle,
+  VfsHandlerMap,
+  VfsFileContent,
+  VfsEntry,
+  VfsListOptions,
+  VfsStatResult,
+  VfsWriteResult,
+} from "@actant/shared";
+
+interface McpConfigRecord {
+  name: string;
+  description?: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface McpConfigManagerLike {
+  list(): McpConfigRecord[];
+  get(name: string): McpConfigRecord | undefined;
+  add(config: McpConfigRecord, persist?: boolean): Promise<void>;
+  update(name: string, patch: Partial<McpConfigRecord>, persist?: boolean): Promise<McpConfigRecord>;
+}
+
+const MCP_CONFIG_FILE_SCHEMA: VfsFileSchemaMap = {
+  "_catalog.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "config": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "write", "stat"],
+  },
+};
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function resolveConfigName(filePath: string): string {
+  const normalized = normalizePath(filePath);
+  if (!normalized || normalized === "_catalog.json" || normalized.includes("/")) {
+    throw new Error(`MCP config path not found: ${filePath}`);
+  }
+  return normalized.replace(/\.json$/i, "");
+}
+
+function parseConfigWrite(name: string, content: string, existing?: McpConfigRecord): McpConfigRecord {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(content) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `Invalid MCP config payload for "${name}": ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  if (parsed == null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`Invalid MCP config payload for "${name}": payload must be a JSON object`);
+  }
+  if ("name" in parsed && parsed.name !== name) {
+    throw new Error(`MCP config payload name "${String(parsed.name)}" does not match path "${name}"`);
+  }
+  if (typeof parsed.command !== "string" || parsed.command.trim().length === 0) {
+    throw new Error(`Invalid MCP config payload for "${name}": "command" must be a non-empty string`);
+  }
+
+  return {
+    name,
+    description: typeof parsed.description === "string" ? parsed.description : existing?.description,
+    command: parsed.command,
+    args: Array.isArray(parsed.args) ? parsed.args as string[] : existing?.args,
+    env: parsed.env != null && typeof parsed.env === "object" && !Array.isArray(parsed.env)
+      ? parsed.env as Record<string, string>
+      : existing?.env,
+  };
+}
+
+export function createMcpConfigSource(
+  manager: McpConfigManagerLike,
+  mountPoint: string,
+  lifecycle: VfsLifecycle,
+): VfsSourceRegistration {
+  const handlers: VfsHandlerMap = {};
+
+  handlers.read = async (filePath: string): Promise<VfsFileContent> => {
+    const normalized = normalizePath(filePath);
+    if (normalized === "_catalog.json") {
+      const catalog = manager.list().map((config) => ({
+        name: config.name,
+        description: config.description,
+        command: config.command,
+        args: config.args ?? [],
+      }));
+      return {
+        content: JSON.stringify(catalog, null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    const name = resolveConfigName(filePath);
+    const config = manager.get(name);
+    if (!config) {
+      throw new Error(`MCP config not found: ${name}`);
+    }
+
+    return {
+      content: JSON.stringify(config, null, 2),
+      mimeType: "application/json",
+    };
+  };
+
+  handlers.write = async (filePath: string, content: string): Promise<VfsWriteResult> => {
+    const name = resolveConfigName(filePath);
+    const existing = manager.get(name);
+    const config = parseConfigWrite(name, content, existing);
+
+    if (existing) {
+      await manager.update(name, config, true);
+    } else {
+      await manager.add(config, true);
+    }
+
+    return {
+      bytesWritten: Buffer.byteLength(content),
+      created: existing == null,
+    };
+  };
+
+  handlers.list = async (dirPath: string, _opts?: VfsListOptions): Promise<VfsEntry[]> => {
+    const normalized = normalizePath(dirPath);
+    if (normalized) {
+      throw new Error(`MCP config path not found: ${dirPath}`);
+    }
+
+    const entries = manager.list().map((config) => ({
+      name: config.name,
+      path: config.name,
+      type: "file" as const,
+    }));
+    entries.unshift({
+      name: "_catalog.json",
+      path: "_catalog.json",
+      type: "file" as const,
+    });
+    return entries;
+  };
+
+  handlers.stat = async (filePath: string): Promise<VfsStatResult> => {
+    const normalized = normalizePath(filePath);
+    if (!normalized) {
+      return { size: 0, type: "directory", mtime: new Date().toISOString() };
+    }
+    if (normalized === "_catalog.json") {
+      return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+    }
+
+    const name = resolveConfigName(filePath);
+    const config = manager.get(name);
+    if (!config) {
+      throw new Error(`MCP config not found: ${name}`);
+    }
+
+    return {
+      size: Buffer.byteLength(JSON.stringify(config)),
+      type: "file",
+      mtime: new Date().toISOString(),
+      mimeType: "application/json",
+    };
+  };
+
+  return {
+    name: "mcp-configs",
+    mountPoint,
+    sourceType: "component-source",
+    lifecycle,
+    metadata: { description: "Built-in MCP config source", virtual: true },
+    fileSchema: MCP_CONFIG_FILE_SCHEMA,
+    handlers,
+  };
+}

--- a/packages/vfs/src/sources/mcp-runtime-source.ts
+++ b/packages/vfs/src/sources/mcp-runtime-source.ts
@@ -1,0 +1,392 @@
+import type {
+  VfsFileContent,
+  VfsEntry,
+  VfsFileSchemaMap,
+  VfsHandlerMap,
+  VfsLifecycle,
+  VfsListOptions,
+  VfsSourceRegistration,
+  VfsStatResult,
+  VfsStreamChunk,
+  VfsWatchEvent,
+  VfsWatchOptions,
+  VfsWriteResult,
+} from "@actant/shared";
+
+export interface McpRuntimeRecord {
+  name: string;
+  status: string;
+  command?: string;
+  args?: string[];
+  transport?: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+export interface McpRuntimeWatchEvent {
+  type: "create" | "modify" | "delete";
+  runtimeName?: string;
+  timestamp?: number;
+}
+
+export interface McpRuntimeSourceProvider {
+  listRuntimes(): McpRuntimeRecord[];
+  getRuntime(name: string): McpRuntimeRecord | undefined;
+  readStream?(name: string, stream: "events"): Promise<VfsFileContent> | VfsFileContent;
+  stream?(name: string, stream: "events"): Promise<AsyncIterable<VfsStreamChunk>> | AsyncIterable<VfsStreamChunk>;
+  writeControl?(name: string, controlPath: "request.json", content: string): Promise<VfsWriteResult>;
+  subscribe?(listener: (event: McpRuntimeWatchEvent) => void): () => void;
+}
+
+const MCP_RUNTIME_FILE_SCHEMA: VfsFileSchemaMap = {
+  "_catalog.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "status.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "streams": {
+    type: "directory",
+    capabilities: ["list", "stat"],
+  },
+  "events": {
+    type: "stream",
+    mimeType: "application/json",
+    capabilities: ["read", "stream", "stat"],
+  },
+  "control": {
+    type: "directory",
+    capabilities: ["list", "stat"],
+  },
+  "request.json": {
+    type: "control",
+    mimeType: "application/json",
+    capabilities: ["read", "write", "stat"],
+  },
+};
+
+type ParsedRuntimePath =
+  | { kind: "root" }
+  | { kind: "catalog" }
+  | { kind: "runtime"; runtimeName: string }
+  | { kind: "status"; runtimeName: string }
+  | { kind: "streams"; runtimeName: string }
+  | { kind: "stream"; runtimeName: string; streamName: string }
+  | { kind: "control"; runtimeName: string }
+  | { kind: "request"; runtimeName: string };
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function parseRuntimePath(filePath: string): ParsedRuntimePath {
+  const normalized = normalizePath(filePath);
+  if (!normalized) {
+    return { kind: "root" };
+  }
+  if (normalized === "_catalog.json") {
+    return { kind: "catalog" };
+  }
+
+  const parts = normalized.split("/");
+  const runtimeName = parts[0];
+  if (!runtimeName) {
+    throw new Error(`MCP runtime path not found: ${filePath}`);
+  }
+
+  if (parts.length === 1) {
+    return { kind: "runtime", runtimeName };
+  }
+  if (parts.length === 2 && parts[1] === "status.json") {
+    return { kind: "status", runtimeName };
+  }
+  if (parts.length === 2 && parts[1] === "streams") {
+    return { kind: "streams", runtimeName };
+  }
+  if (parts.length === 3 && parts[1] === "streams") {
+    return { kind: "stream", runtimeName, streamName: parts[2] ?? "" };
+  }
+  if (parts.length === 2 && parts[1] === "control") {
+    return { kind: "control", runtimeName };
+  }
+  if (parts.length === 3 && parts[1] === "control" && parts[2] === "request.json") {
+    return { kind: "request", runtimeName };
+  }
+
+  throw new Error(`MCP runtime path not found: ${filePath}`);
+}
+
+function requireRuntime(
+  provider: McpRuntimeSourceProvider,
+  runtimeName: string,
+): McpRuntimeRecord {
+  const runtime = provider.getRuntime(runtimeName);
+  if (!runtime) {
+    throw new Error(`MCP runtime not found: ${runtimeName}`);
+  }
+  return runtime;
+}
+
+function serializeEventSnapshot(runtime: McpRuntimeRecord): string {
+  return JSON.stringify(
+    {
+      type: "snapshot",
+      runtime,
+      timestamp: Date.now(),
+    },
+    null,
+    2,
+  );
+}
+
+function parseControlRequest(runtimeName: string, content: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(
+      `Invalid control request for runtime "${runtimeName}": ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  if (parsed == null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`Invalid control request for runtime "${runtimeName}": payload must be a JSON object`);
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+function matchesWatchTarget(requestedPath: string, eventPath: string): boolean {
+  const normalizedRequested = normalizePath(requestedPath);
+  if (!normalizedRequested) {
+    return true;
+  }
+  return eventPath === normalizedRequested || eventPath.startsWith(`${normalizedRequested}/`);
+}
+
+function eventPathsForRuntimeEvent(event: McpRuntimeWatchEvent): string[] {
+  const runtimeName = event.runtimeName;
+  if (!runtimeName) {
+    return ["status.json"];
+  }
+  if (event.type === "create" || event.type === "delete") {
+    return [runtimeName, `${runtimeName}/status.json`];
+  }
+  return [`${runtimeName}/status.json`];
+}
+
+async function* oneShotStream(content: VfsFileContent): AsyncGenerator<VfsStreamChunk> {
+  if (content.content.length === 0) {
+    return;
+  }
+  yield {
+    content: content.content,
+    mimeType: content.mimeType,
+    encoding: content.encoding,
+    timestamp: Date.now(),
+  };
+}
+
+export function createMcpRuntimeSource(
+  provider: McpRuntimeSourceProvider,
+  mountPoint: string,
+  lifecycle: VfsLifecycle,
+): VfsSourceRegistration {
+  const handlers: VfsHandlerMap = {};
+
+  handlers.read = async (filePath: string): Promise<VfsFileContent> => {
+    const parsed = parseRuntimePath(filePath);
+
+    if (parsed.kind === "catalog") {
+      return {
+        content: JSON.stringify(provider.listRuntimes(), null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    if (parsed.kind === "status") {
+      return {
+        content: JSON.stringify(requireRuntime(provider, parsed.runtimeName), null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    if (parsed.kind === "stream") {
+      const runtime = requireRuntime(provider, parsed.runtimeName);
+      const streamName = requireEventsStream(parsed.streamName);
+      if (provider.readStream) {
+        return provider.readStream(parsed.runtimeName, streamName);
+      }
+      return {
+        content: serializeEventSnapshot(runtime),
+        mimeType: "application/json",
+      };
+    }
+
+    if (parsed.kind === "request") {
+      requireRuntime(provider, parsed.runtimeName);
+      return {
+        content: "{}",
+        mimeType: "application/json",
+      };
+    }
+
+    throw new Error(`MCP runtime path not readable: ${filePath}`);
+  };
+
+  handlers.write = async (filePath: string, content: string): Promise<VfsWriteResult> => {
+    const parsed = parseRuntimePath(filePath);
+    if (parsed.kind !== "request") {
+      throw new Error(`MCP runtime path is not writable: ${filePath}`);
+    }
+
+    requireRuntime(provider, parsed.runtimeName);
+    parseControlRequest(parsed.runtimeName, content);
+
+    if (!provider.writeControl) {
+      throw new Error(`Capability "write" not supported for path "${parsed.runtimeName}/control/request.json"`);
+    }
+
+    return provider.writeControl(parsed.runtimeName, "request.json", content);
+  };
+
+  handlers.list = async (dirPath: string, _opts?: VfsListOptions): Promise<VfsEntry[]> => {
+    const parsed = parseRuntimePath(dirPath);
+
+    if (parsed.kind === "root") {
+      const entries: VfsEntry[] = provider.listRuntimes().map((runtime) => ({
+        name: runtime.name,
+        path: runtime.name,
+        type: "directory" as const,
+      }));
+      entries.unshift({
+        name: "_catalog.json",
+        path: "_catalog.json",
+        type: "file",
+      });
+      return entries;
+    }
+
+    if (parsed.kind === "runtime") {
+      requireRuntime(provider, parsed.runtimeName);
+      return [
+        { name: "status.json", path: `${parsed.runtimeName}/status.json`, type: "file" },
+        { name: "streams", path: `${parsed.runtimeName}/streams`, type: "directory" },
+        { name: "control", path: `${parsed.runtimeName}/control`, type: "directory" },
+      ];
+    }
+
+    if (parsed.kind === "streams") {
+      requireRuntime(provider, parsed.runtimeName);
+      return [
+        { name: "events", path: `${parsed.runtimeName}/streams/events`, type: "file" },
+      ];
+    }
+
+    if (parsed.kind === "control") {
+      requireRuntime(provider, parsed.runtimeName);
+      return [
+        { name: "request.json", path: `${parsed.runtimeName}/control/request.json`, type: "file" },
+      ];
+    }
+
+    throw new Error(`MCP runtime path not listable: ${dirPath}`);
+  };
+
+  handlers.stat = async (filePath: string): Promise<VfsStatResult> => {
+    const parsed = parseRuntimePath(filePath);
+    if (parsed.kind === "root" || parsed.kind === "runtime" || parsed.kind === "streams" || parsed.kind === "control") {
+      return { size: 0, type: "directory", mtime: new Date().toISOString() };
+    }
+    if (parsed.kind === "catalog") {
+      return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+    }
+    if (parsed.kind === "status") {
+      const runtime = requireRuntime(provider, parsed.runtimeName);
+      return {
+        size: Buffer.byteLength(JSON.stringify(runtime)),
+        type: "file",
+        mtime: runtime.updatedAt ?? new Date().toISOString(),
+        mimeType: "application/json",
+      };
+    }
+    if (parsed.kind === "stream") {
+      requireRuntime(provider, parsed.runtimeName);
+      requireEventsStream(parsed.streamName);
+      return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+    }
+
+    requireRuntime(provider, parsed.runtimeName);
+    return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+  };
+
+  handlers.watch = (
+    pattern: string,
+    callback: (event: VfsWatchEvent) => void,
+    opts?: VfsWatchOptions,
+  ) => {
+    if (!provider.subscribe) {
+      return () => undefined;
+    }
+
+    return provider.subscribe((event) => {
+      if (opts?.events && !opts.events.includes(event.type)) {
+        return;
+      }
+      for (const eventPath of eventPathsForRuntimeEvent(event)) {
+        if (!matchesWatchTarget(pattern, eventPath)) {
+          continue;
+        }
+        callback({
+          type: event.type,
+          path: eventPath,
+          timestamp: event.timestamp ?? Date.now(),
+        });
+      }
+    });
+  };
+
+  handlers.stream = async (filePath: string): Promise<AsyncIterable<VfsStreamChunk>> => {
+    const parsed = parseRuntimePath(filePath);
+    if (parsed.kind !== "stream") {
+      throw new Error(`Stream not found: ${filePath}`);
+    }
+
+    const runtime = requireRuntime(provider, parsed.runtimeName);
+    const streamName = requireEventsStream(parsed.streamName);
+
+    if (provider.stream) {
+      return provider.stream(parsed.runtimeName, streamName);
+    }
+    if (provider.readStream) {
+      const content = await provider.readStream(parsed.runtimeName, streamName);
+      return oneShotStream(content);
+    }
+
+    return oneShotStream({
+      content: serializeEventSnapshot(runtime),
+      mimeType: "application/json",
+    });
+  };
+
+  return {
+    name: "mcp-runtime",
+    mountPoint,
+    sourceType: "component-source",
+    lifecycle,
+    metadata: { description: "Built-in MCP runtime source", virtual: true },
+    fileSchema: MCP_RUNTIME_FILE_SCHEMA,
+    handlers,
+  };
+}
+function requireEventsStream(streamName: string): "events" {
+  if (streamName !== "events") {
+    throw new Error(`Stream not found: ${streamName}`);
+  }
+  return streamName;
+}

--- a/packages/vfs/src/sources/skill-source.ts
+++ b/packages/vfs/src/sources/skill-source.ts
@@ -1,0 +1,190 @@
+import type {
+  VfsSourceRegistration,
+  VfsFileSchemaMap,
+  VfsLifecycle,
+  VfsHandlerMap,
+  VfsFileContent,
+  VfsEntry,
+  VfsListOptions,
+  VfsStatResult,
+  VfsWriteResult,
+} from "@actant/shared";
+
+interface SkillRecord {
+  name: string;
+  description?: string;
+  content?: string;
+  tags?: string[];
+}
+
+interface SkillManagerLike {
+  list(): SkillRecord[];
+  get(name: string): SkillRecord | undefined;
+  add(skill: SkillRecord, persist?: boolean): Promise<void>;
+  update(name: string, patch: Partial<SkillRecord>, persist?: boolean): Promise<SkillRecord>;
+}
+
+const SKILL_FILE_SCHEMA: VfsFileSchemaMap = {
+  "_catalog.json": {
+    type: "json",
+    mimeType: "application/json",
+    capabilities: ["read", "stat"],
+  },
+  "skill": {
+    type: "text",
+    mimeType: "text/markdown",
+    capabilities: ["read", "write", "stat"],
+  },
+};
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function resolveSkillName(filePath: string): string {
+  const normalized = normalizePath(filePath);
+  if (!normalized || normalized === "_catalog.json" || normalized.includes("/")) {
+    throw new Error(`Skill path not found: ${filePath}`);
+  }
+  return normalized.replace(/\.(md|json|ya?ml)$/i, "");
+}
+
+function toCatalogEntry(skill: SkillRecord): Record<string, unknown> {
+  return {
+    name: skill.name,
+    description: skill.description,
+    tags: skill.tags,
+  };
+}
+
+function parseSkillWrite(name: string, content: string, existing?: SkillRecord): SkillRecord {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (parsed == null || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error("Skill payload must be a JSON object");
+    }
+    if ("name" in parsed && parsed.name !== name) {
+      throw new Error(`Skill payload name "${String(parsed.name)}" does not match path "${name}"`);
+    }
+    return {
+      name,
+      description: typeof parsed.description === "string" ? parsed.description : existing?.description,
+      content: typeof parsed.content === "string" ? parsed.content : existing?.content,
+      tags: Array.isArray(parsed.tags) ? parsed.tags as string[] : existing?.tags,
+    };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {
+        ...existing,
+        name,
+        content,
+      };
+    }
+    throw error;
+  }
+}
+
+export function createSkillSource(
+  manager: SkillManagerLike,
+  mountPoint: string,
+  lifecycle: VfsLifecycle,
+): VfsSourceRegistration {
+  const handlers: VfsHandlerMap = {};
+
+  handlers.read = async (filePath: string): Promise<VfsFileContent> => {
+    const normalized = normalizePath(filePath);
+
+    if (normalized === "_catalog.json") {
+      const catalog = manager.list().map(toCatalogEntry);
+      return {
+        content: JSON.stringify(catalog, null, 2),
+        mimeType: "application/json",
+      };
+    }
+
+    const name = resolveSkillName(filePath);
+    const skill = manager.get(name);
+    if (!skill) {
+      throw new Error(`Skill not found: ${name}`);
+    }
+
+    if (typeof skill.content === "string") {
+      return { content: skill.content, mimeType: "text/markdown" };
+    }
+
+    return {
+      content: JSON.stringify(skill, null, 2),
+      mimeType: "application/json",
+    };
+  };
+
+  handlers.write = async (filePath: string, content: string): Promise<VfsWriteResult> => {
+    const name = resolveSkillName(filePath);
+    const existing = manager.get(name);
+    const skill = parseSkillWrite(name, content, existing);
+
+    if (existing) {
+      await manager.update(name, skill, true);
+    } else {
+      await manager.add(skill, true);
+    }
+
+    return {
+      bytesWritten: Buffer.byteLength(content),
+      created: existing == null,
+    };
+  };
+
+  handlers.list = async (dirPath: string, _opts?: VfsListOptions): Promise<VfsEntry[]> => {
+    const normalized = normalizePath(dirPath);
+    if (normalized) {
+      throw new Error(`Skill path not found: ${dirPath}`);
+    }
+
+    const entries = manager.list().map((skill) => ({
+      name: skill.name,
+      path: skill.name,
+      type: "file" as const,
+    }));
+    entries.unshift({
+      name: "_catalog.json",
+      path: "_catalog.json",
+      type: "file" as const,
+    });
+    return entries;
+  };
+
+  handlers.stat = async (filePath: string): Promise<VfsStatResult> => {
+    const normalized = normalizePath(filePath);
+    if (!normalized) {
+      return { size: 0, type: "directory", mtime: new Date().toISOString() };
+    }
+    if (normalized === "_catalog.json") {
+      return { size: 0, type: "file", mtime: new Date().toISOString(), mimeType: "application/json" };
+    }
+
+    const name = resolveSkillName(filePath);
+    const skill = manager.get(name);
+    if (!skill) {
+      throw new Error(`Skill not found: ${name}`);
+    }
+
+    const serialized = typeof skill.content === "string" ? skill.content : JSON.stringify(skill);
+    return {
+      size: Buffer.byteLength(serialized),
+      type: "file",
+      mtime: new Date().toISOString(),
+      mimeType: typeof skill.content === "string" ? "text/markdown" : "application/json",
+    };
+  };
+
+  return {
+    name: "skills",
+    mountPoint,
+    sourceType: "component-source",
+    lifecycle,
+    metadata: { description: "Built-in skill source", virtual: true },
+    fileSchema: SKILL_FILE_SCHEMA,
+    handlers,
+  };
+}


### PR DESCRIPTION
## Summary

- Implement M5: control node write-to-execute and stream node stable consumption
- Create 4 built-in VFS source files completing the M4→M5 pipeline
- Establish unified VFS execution surface — no separate invoke API

## Changes

- **`packages/vfs/src/sources/skill-source.ts`** — SkillSource with read/write/list/stat
- **`packages/vfs/src/sources/mcp-config-source.ts`** — McpConfigSource with read/write/list/stat
- **`packages/vfs/src/sources/mcp-runtime-source.ts`** — McpRuntimeSource with control write, events stream, watch, synthetic fallback
- **`packages/vfs/src/sources/agent-runtime-source.ts`** — AgentRuntimeSource with control write (request.json), stdout/stderr stream, watch integration
- **`packages/vfs/src/__tests__/m5-control-stream-e2e.test.ts`** — E2E acceptance tests

## Key Design Decisions

- Control nodes (`control/request.json`) are the sole execution entry point via VFS `write`
- Stream nodes (`streams/stdout`, `streams/stderr`, `streams/events`) support both provider-backed streaming and synthetic one-shot fallback
- Error semantics: `invalid control request`, `stream not found`, `capability not supported`
- All source factories accept minimal `*Like` interfaces for testability

## Test Plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — all packages pass
- [x] `pnpm test` — 120 files / 1339 tests pass
- [x] M5 E2E tests: control write → execute → stream consumption verified
- [x] No console.log, explicit any, or non-null assertions in source files

## Related Issues

Closes M5 milestone in `docs/planning/contextfs-roadmap.md`

Made with [Cursor](https://cursor.com)